### PR TITLE
Make it possible to use node-fetch in HTTPService

### DIFF
--- a/packages/core/tests/base.test.ts
+++ b/packages/core/tests/base.test.ts
@@ -17,11 +17,13 @@ describe("Abby", () => {
     const variants = ["variant1", "variant2"];
 
     const abby = new Abby({
-      projectId: "",
-      tests: {
-        a: { variants },
-        b: {
-          variants: ["test"],
+      config: {
+        projectId: "",
+        tests: {
+          a: { variants },
+          b: {
+            variants: ["test"],
+          },
         },
       },
     });
@@ -33,9 +35,11 @@ describe("Abby", () => {
     const variants = ["variant1", "variant2"];
 
     const abby = new Abby({
-      projectId: "",
-      tests: {
-        a: { variants },
+      config: {
+        projectId: "",
+        tests: {
+          a: { variants },
+        },
       },
     });
 
@@ -46,8 +50,10 @@ describe("Abby", () => {
 
   it("gets a feature flag", () => {
     const abby = new Abby({
-      projectId: "",
-      flags: ["flag1", "flag2"],
+      config: {
+        projectId: "",
+        flags: ["flag1", "flag2"],
+      },
     });
 
     expect(abby.getFeatureFlag("flag1")).toBeDefined();
@@ -56,12 +62,14 @@ describe("Abby", () => {
 
   it("uses the devOverrides", () => {
     const abby = new Abby({
-      projectId: "",
-      flags: ["flag1", "flag2"],
-      settings: {
-        flags: {
-          devOverrides: {
-            flag1: false,
+      config: {
+        projectId: "",
+        flags: ["flag1", "flag2"],
+        settings: {
+          flags: {
+            devOverrides: {
+              flag1: false,
+            },
           },
         },
       },
@@ -80,11 +88,13 @@ describe("Abby", () => {
     process.env.NODE_ENV = "development";
 
     const abby = new Abby({
-      projectId: "",
-      tests: {
-        a: { variants: ["variant1", "variant2"] },
-        b: {
-          variants: ["test"],
+      config: {
+        projectId: "",
+        tests: {
+          a: { variants: ["variant1", "variant2"] },
+          b: {
+            variants: ["test"],
+          },
         },
       },
     });
@@ -98,8 +108,10 @@ describe("Abby", () => {
 
   it("updates local feature flag", () => {
     const abby = new Abby({
-      projectId: "",
-      flags: ["flag1", "flag2"],
+      config: {
+        projectId: "",
+        flags: ["flag1", "flag2"],
+      },
     });
 
     abby.init({ flags: [{ name: "flag1", isEnabled: true }], tests: [] });

--- a/packages/core/tests/setup.ts
+++ b/packages/core/tests/setup.ts
@@ -1,10 +1,6 @@
 import { expect, afterEach } from "vitest";
 
 import { server } from "./mocks/server";
-import fetch from "node-fetch";
-
-/// @ts-ignore
-global.fetch = fetch;
 
 // Establish API mocking before all tests.
 beforeAll(() => server.listen());

--- a/packages/core/tests/types.test.ts
+++ b/packages/core/tests/types.test.ts
@@ -4,28 +4,26 @@ import { Abby } from "../src/index";
 describe("types", () => {
   it("produces proper types", () => {
     const abby = new Abby({
-      projectId: "",
-      flags: ["flag1", "flag2"],
-      tests: {
-        test1: {
-          variants: ["firstVariant", "secondVariant"],
-        },
-        test2: {
-          variants: ["some-random-string", "abc"],
+      config: {
+        projectId: "",
+        flags: ["flag1", "flag2"],
+        tests: {
+          test1: {
+            variants: ["firstVariant", "secondVariant"],
+          },
+          test2: {
+            variants: ["some-random-string", "abc"],
+          },
         },
       },
     });
 
     assertType<boolean>(abby.getFeatureFlag("flag1"));
-    expectTypeOf(abby.getFeatureFlag)
-      .parameter(0)
-      .toEqualTypeOf<"flag1" | "flag2">();
+    expectTypeOf(abby.getFeatureFlag).parameter(0).toEqualTypeOf<"flag1" | "flag2">();
 
     assertType<"firstVariant" | "secondVariant">(abby.getTestVariant("test1"));
 
-    expectTypeOf(abby.getTestVariant)
-      .parameter(0)
-      .toEqualTypeOf<"test1" | "test2">();
+    expectTypeOf(abby.getTestVariant).parameter(0).toEqualTypeOf<"test1" | "test2">();
 
     // This is the potential type of the devOverrides
     type DevOverrides = NonNullable<


### PR DESCRIPTION
Description: This PR updates the implementation of the HttpService in the Core package to utilize the cross-fetch library. 
The changes are needed in order to prepare for the upcoming NodeJs SDK which relies on using the core.

Remove NodeFetch and fix tests

- [ ] angular
- [ ] core
- [ ] react
- [ ] next
- [ ] svelte
- [ ] nodejs