### PR TITLE
feat(angular): fix rerendering in directives and usage of dynamic properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,4 +7,7 @@ module.exports = {
       rootDir: ["apps/*/"],
     },
   },
+  rules: {
+    eqeqeq: "error",
+  },
 };

--- a/apps/angular-example/src/app/app-routing.module.ts
+++ b/apps/angular-example/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { CTestComponent } from './test_components/c.component';
 import { DTestComponent } from './test_components/d.component';
 import { FlagComponent } from './test_components/flag.component';
 import { Abby } from './abby';
-import { combineLatest, forkJoin, tap } from 'rxjs';
+import { combineLatest } from 'rxjs';
 
 @NgModule({
   imports: [
@@ -20,8 +20,8 @@ import { combineLatest, forkJoin, tap } from 'rxjs';
 export class AppRoutingModule {
   constructor(private abby: Abby, private router: Router) {
     combineLatest({
-      angularTest: abby.getVariant('AngularTest').pipe(tap((val) => console.warn(val))),
-      angularFlag: abby.getFeatureFlagValue('AngularFlag').pipe(tap((val) => console.warn(val))),
+      angularTest: abby.getVariant('AngularTest'),
+      angularFlag: abby.getFeatureFlagValue('AngularFlag'),
     }).subscribe(({ angularTest, angularFlag }) => {
       this.router.resetConfig([
         {

--- a/apps/angular-example/src/app/app-routing.module.ts
+++ b/apps/angular-example/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { CTestComponent } from './test_components/c.component';
 import { DTestComponent } from './test_components/d.component';
 import { FlagComponent } from './test_components/flag.component';
 import { Abby } from './abby';
-import { forkJoin } from 'rxjs';
+import { combineLatest, forkJoin, tap } from 'rxjs';
 
 @NgModule({
   imports: [
@@ -19,9 +19,9 @@ import { forkJoin } from 'rxjs';
 })
 export class AppRoutingModule {
   constructor(private abby: Abby, private router: Router) {
-    forkJoin({
-      angularTest: abby.getVariant('AngularTest'),
-      angularFlag: abby.getFeatureFlagValue('AngularFlag'),
+    combineLatest({
+      angularTest: abby.getVariant('AngularTest').pipe(tap((val) => console.warn(val))),
+      angularFlag: abby.getFeatureFlagValue('AngularFlag').pipe(tap((val) => console.warn(val))),
     }).subscribe(({ angularTest, angularFlag }) => {
       this.router.resetConfig([
         {

--- a/apps/angular-example/src/app/app-routing.module.ts
+++ b/apps/angular-example/src/app/app-routing.module.ts
@@ -19,6 +19,10 @@ import { combineLatest } from 'rxjs';
 })
 export class AppRoutingModule {
   constructor(private abby: Abby, private router: Router) {
+    // we are using `combineLatest` here, as the devtools can dynamically
+    // change the state of our feature flags during runtime.
+    // In a live environment, where flags and variants are determined once,
+    // you can use `forkJoin` here
     combineLatest({
       angularTest: abby.getVariant('AngularTest'),
       angularFlag: abby.getFeatureFlagValue('AngularFlag'),

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -13,7 +13,7 @@
 
 <h4
   *ngIf="angularTest$ | async as angularTest"
-  [ngStyle]="{'color': angularTest === 'A' ? 'blue' : angularTest === 'B' ? 'green' : angularTest === 'C' ? 'yellow' : angularTest === 'D' ? 'pink' : 'grey'}"
+  [ngStyle]="{'color': headerColor$ | async }"
 >
   Test
 </h4>
@@ -49,7 +49,7 @@
   <option value="!AngularFlag2">!AngularFlag2</option>
 </select>
 
-<div *featureFlag="dynamicFeatureFlag.value">{{ dynamicFeatureFlag.value }} = ON</div>
+<div *featureFlag="dynamicFeatureFlag.value ?? ''">{{ dynamicFeatureFlag.value }} = ON</div>
 
 <h3>Router A/B Test Demo</h3>
 <nav>

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -1,7 +1,7 @@
 <h1>Angular examples</h1>
 
 <h3>Simple A/B-Test Service Demo</h3>
-<div>angularTest = {{angularTest}}</div>
+<div>angularTest = {{ angularTest$ | async }}</div>
 
 <button (click)="onAct()">OnAct</button>
 
@@ -11,11 +11,15 @@
 <ng-container *abbyTest="{testName: 'AngularTest', variant: 'C'}">CCCCCC</ng-container>
 <ng-container *abbyTest="{testName: 'AngularTest', variant: 'D'}">DDDDDD</ng-container>
 
-<h4 [ngStyle]="{'color': angularTest === 'A' ? 'blue' : angularTest === 'B' ? 'green' : angularTest === 'C' ? 'yellow' : angularTest === 'D' ? 'pink' : 'grey'}">Test</h4>
-
+<h4
+  *ngIf="angularTest$ | async as angularTest"
+  [ngStyle]="{'color': angularTest === 'A' ? 'blue' : angularTest === 'B' ? 'green' : angularTest === 'C' ? 'yellow' : angularTest === 'D' ? 'pink' : 'grey'}"
+>
+  Test
+</h4>
 
 <h3>Simple Feature Flag Service Demo</h3>
-<div>angularFlag = {{angularFlag}}</div>
+<div>angularFlag = {{ angularFlag$ | async }}</div>
 
 <h3>Simple Feature Flag Directive Demo</h3>
 <div *featureFlag="'AngularFlag'">AngularFlag = ON</div>
@@ -29,7 +33,7 @@
 <h4>Feature Flag</h4>
 <div *featureFlag="'!NotExistingFlag'">AngularFlag = OFF</div>
 
-<div ></div>
+<div></div>
 <h4>Variants</h4>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'A'}">AAAAAA</ng-container>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'B'}">BBBBBB</ng-container>
@@ -44,32 +48,28 @@
 <h3>Router A/B Test Demo</h3>
 <nav>
   <ul>
-    <li><a [routerLink]="[{outlets: {test: 'test'}}]"  >Test</a></li>
+    <li><a [routerLink]="[{outlets: {test: 'test'}}]">Test</a></li>
   </ul>
 </nav>
 <router-outlet name="test"></router-outlet>
-
-
 
 <h3>Router Feature Flag Demo</h3>
 <div *featureFlag="'AngularFlag'">
   <nav>
     <ul>
-      <li><a [routerLink]="[{outlets: {flag: 'flag'}}]" >Feature</a></li>
+      <li><a [routerLink]="[{outlets: {flag: 'flag'}}]">Feature</a></li>
     </ul>
   </nav>
 </div>
 <router-outlet name="flag"></router-outlet>
 
-
 <h3>Lazy-loaded module Demo</h3>
 <nav>
   <ul>
-    <li><a [routerLink]="[{outlets: {lazy: 'lazy'}}]" >Lazy</a></li>
+    <li><a [routerLink]="[{outlets: {lazy: 'lazy'}}]">Lazy</a></li>
   </ul>
 </nav>
 <router-outlet name="lazy"></router-outlet>
-
 
 <h3>Angular Universal SSR Demo</h3>
 <!-- todo -->

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -22,16 +22,16 @@
 <div>angularFlag = {{ angularFlag$ | async }}</div>
 
 <h3>Simple Feature Flag Directive Demo</h3>
-<div *featureFlag="'AngularFlag'">AngularFlag = ON</div>
+<div *abbyFlag="'AngularFlag'">AngularFlag = ON</div>
 
-<div *featureFlag="'!AngularFlag'">AngularFlag = OFF</div>
+<div *abbyFlag="'!AngularFlag'">AngularFlag = OFF</div>
 
 <h3>Config UI Tool Demo</h3>
 <abby-devtools [props]="{dangerouslyForceShow: true}"></abby-devtools>
 
 <h3>Default usage Demo</h3>
 <h4>Feature Flag</h4>
-<div *featureFlag="'!NotExistingFlag'">AngularFlag = OFF</div>
+<div *abbyFlag="'!NotExistingFlag'">AngularFlag = OFF</div>
 
 <h4>Variants</h4>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'A'}">AAAAAA</ng-container>
@@ -49,7 +49,7 @@
   <option value="!AngularFlag2">!AngularFlag2</option>
 </select>
 
-<div *featureFlag="dynamicFeatureFlag.value ?? ''">{{ dynamicFeatureFlag.value }} = ON</div>
+<div *abbyFlag="dynamicFeatureFlag.value ?? ''">{{ dynamicFeatureFlag.value }} = ON</div>
 
 <h3>Router A/B Test Demo</h3>
 <nav>
@@ -60,7 +60,7 @@
 <router-outlet name="test"></router-outlet>
 
 <h3>Router Feature Flag Demo</h3>
-<div *featureFlag="'AngularFlag'">
+<div *abbyFlag="'AngularFlag'">
   <nav>
     <ul>
       <li><a [routerLink]="[{outlets: {flag: 'flag'}}]">Feature</a></li>

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -33,7 +33,6 @@
 <h4>Feature Flag</h4>
 <div *featureFlag="'!NotExistingFlag'">AngularFlag = OFF</div>
 
-<div></div>
 <h4>Variants</h4>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'A'}">AAAAAA</ng-container>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'B'}">BBBBBB</ng-container>

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -43,7 +43,14 @@
 <!-- todo -->
 
 <h3>Feature Flag live change Demo</h3>
-<!-- todo -->
+<select [formControl]="dynamicFeatureFlag">
+  <option value="AngularFlag">AngularFlag</option>
+  <option value="!AngularFlag">!AngularFlag</option>
+  <option value="AngularFlag2">AngularFlag2</option>
+  <option value="!AngularFlag2">!AngularFlag2</option>
+</select>
+
+<div *featureFlag="dynamicFeatureFlag.value">{{ dynamicFeatureFlag.value }} = ON</div>
 
 <h3>Router A/B Test Demo</h3>
 <nav>

--- a/apps/angular-example/src/app/app.component.ts
+++ b/apps/angular-example/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { FormControl } from "@angular/forms";
-import { shareReplay } from "rxjs";
+import { map, shareReplay } from "rxjs";
 import { Abby } from "./abby";
 
 @Component({
@@ -12,7 +12,24 @@ export class AppComponent {
   angularTest$ = this.abby.getVariant("AngularTest").pipe(shareReplay(1));
   angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag").pipe(shareReplay(1));
 
-  dynamicFeatureFlag = new FormControl();
+  headerColor$ = this.angularTest$.pipe(
+    map((angularTest) => {
+      switch(angularTest) {
+        case 'A':
+          return 'blue';
+        case 'B':
+          return 'green';
+        case 'C':
+          return 'yellow';
+        case 'D':
+          return 'pink';
+        default:
+          return 'grey';
+      }
+    })
+  );
+
+  dynamicFeatureFlag = new FormControl<string | null>(null);
 
   constructor(public readonly abby: Abby) {}
 

--- a/apps/angular-example/src/app/app.component.ts
+++ b/apps/angular-example/src/app/app.component.ts
@@ -1,27 +1,19 @@
-import { Component, OnInit } from '@angular/core';
-import { Abby } from './abby';
+import { Component } from "@angular/core";
+import { shareReplay } from "rxjs";
+import { Abby } from "./abby";
 
 @Component({
-  selector: 'app-root',
-  templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css'],
+  selector: "app-root",
+  templateUrl: "./app.component.html",
+  styleUrls: ["./app.component.css"],
 })
-export class AppComponent implements OnInit {
-  angularTest: string;
-  angularFlag: boolean;
+export class AppComponent {
+  angularTest$ = this.abby.getVariant("AngularTest").pipe(shareReplay(1));
+  angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag").pipe(shareReplay(1));
+
   constructor(public readonly abby: Abby) {}
 
-  ngOnInit() {
-    this.abby.getVariant('AngularTest').subscribe((value: string) => {
-      this.angularTest = value;
-    });
-
-    this.abby.getFeatureFlagValue('AngularFlag').subscribe((value: boolean) => {
-      this.angularFlag = value;
-    });
-  }
-
   public onAct(): void {
-    this.abby.onAct('AngularTest');
+    this.abby.onAct("AngularTest");
   }
 }

--- a/apps/angular-example/src/app/app.component.ts
+++ b/apps/angular-example/src/app/app.component.ts
@@ -1,4 +1,5 @@
 import { Component } from "@angular/core";
+import { FormControl } from "@angular/forms";
 import { shareReplay } from "rxjs";
 import { Abby } from "./abby";
 
@@ -10,6 +11,8 @@ import { Abby } from "./abby";
 export class AppComponent {
   angularTest$ = this.abby.getVariant("AngularTest").pipe(shareReplay(1));
   angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag").pipe(shareReplay(1));
+
+  dynamicFeatureFlag = new FormControl();
 
   constructor(public readonly abby: Abby) {}
 

--- a/apps/angular-example/src/app/app.component.ts
+++ b/apps/angular-example/src/app/app.component.ts
@@ -1,6 +1,6 @@
 import { Component } from "@angular/core";
 import { FormControl } from "@angular/forms";
-import { map, shareReplay } from "rxjs";
+import { map } from "rxjs";
 import { Abby } from "./abby";
 
 @Component({
@@ -9,8 +9,8 @@ import { Abby } from "./abby";
   styleUrls: ["./app.component.css"],
 })
 export class AppComponent {
-  angularTest$ = this.abby.getVariant("AngularTest").pipe(shareReplay(1));
-  angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag").pipe(shareReplay(1));
+  angularTest$ = this.abby.getVariant("AngularTest");
+  angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag");
 
   headerColor$ = this.angularTest$.pipe(
     map((angularTest) => {

--- a/apps/angular-example/src/app/app.module.ts
+++ b/apps/angular-example/src/app/app.module.ts
@@ -10,6 +10,7 @@ import { CTestComponent } from './test_components/c.component';
 import { DTestComponent } from './test_components/d.component';
 import { FlagComponent } from './test_components/flag.component';
 import { abby } from './abby';
+import { ReactiveFormsModule } from '@angular/forms';
 
 @NgModule({
   declarations: [
@@ -24,6 +25,7 @@ import { abby } from './abby';
     ///BrowserModule.withServerTransition({ appId: 'angular-example' }), // for SSR
     BrowserModule,
     AppRoutingModule,
+    ReactiveFormsModule,
     AbbyModule.forRoot(abby),
   ],
   providers: [],

--- a/apps/angular-example/src/app/lazy/lazy.component.ts
+++ b/apps/angular-example/src/app/lazy/lazy.component.ts
@@ -3,16 +3,10 @@ import { Abby } from '../abby';
 
 @Component({
   selector: 'app-lazy',
-  template: '<div>angularTest = {{angularTest}}</div>',
+  template: '<div>angularTest = {{ angularTest | async}}</div>',
 })
 export class LazyComponent {
-  angularTest: string;
+  angularTest = this.abby.getVariant('AngularTest');
 
   constructor(private readonly abby: Abby) {}
-
-  ngOnInit() {
-    this.abby.getVariant('AngularTest').subscribe((variant: string) => {
-      this.angularTest = variant;
-    });
-  }
 }

--- a/apps/angular-example/src/app/lazy/lazy.component.ts
+++ b/apps/angular-example/src/app/lazy/lazy.component.ts
@@ -3,10 +3,10 @@ import { Abby } from '../abby';
 
 @Component({
   selector: 'app-lazy',
-  template: '<div>angularTest = {{ angularTest | async}}</div>',
+  template: '<div>angularTest = {{ angularTest$ | async}}</div>',
 })
 export class LazyComponent {
-  angularTest = this.abby.getVariant('AngularTest');
+  angularTest$ = this.abby.getVariant('AngularTest');
 
   constructor(private readonly abby: Abby) {}
 }

--- a/apps/docs/pages/integrations/angular.mdx
+++ b/apps/docs/pages/integrations/angular.mdx
@@ -64,20 +64,16 @@ export class AppModule {}
 
 ### Using Abby in your Component
 
-You can now use Abby in your components. You will have access to the `AbbyService` which can be used to get the variant and act on any test.
+You can now use Abby in your components. You will have access to the `AbbyService` which can be used to get one of your variants, a feature flag or act on any test.
 
 ```tsx
 import { AbbyService } from '@tryabby/angular';
 
 @Component({...})
 export class MyComponent {
-  footerVariant: string;
+  footerVariant$ = this.abbyService.getVariant('footer');
 
-  constructor(private abbyService: AbbyService) {
-    this.abbyService.getVariant('footer').subscribe((variant) => {
-      this.footerVariant = variant;
-    });
-  }
+  constructor(private abbyService: AbbyService) { }
 
   onAct() {
     this.abbyService.onAct('footer');
@@ -85,18 +81,13 @@ export class MyComponent {
 }
 ```
 
-<Callout>
-  For this Example "strictPropertyInitialization" has to be set to false in your tsconfig. Otherwise
-  you have to initialize "footerVariant" with an default value.
-</Callout>
-
 ### Using Abby Directives
 
-You can also use Abby's directives to conditionally show elements based on the variant or feature flag.
+You can also use Abby's directives to conditionally render elements based on the variant or feature flag.
 
 ```html
-<ng-container *featureFlag="'newFeature'">
-  <!-- This will only be shown if the newFeature flag is active. -->
+<ng-container *abbyFlag="'newFeature'">
+  <!-- This will only be shown if the newFeature flag is truthy. -->
   <p>Here is the new feature</p>
 </ng-container>
 
@@ -104,12 +95,47 @@ You can also use Abby's directives to conditionally show elements based on the v
   <!-- This will only be shown if the test variant matches the variant. -->
   <p>Here is Variant A</p>
 </ng-container>
+```
 
+The `*abbyFlag`-Directive for now only interprets feature flags as a boolean. Support for checking string, number or object values will come later.
+You can however invert the boolean it returns by putting a `!` in front of the flag name like so:
+```html
+<ng-container *abbyFlag="'!newFeature'">
+  <!-- This will only be shown if the newFeature flag is falsy. -->
+</ng-container>
+```
+
+For using variants inside an `ngStyle`-Directive, we advice you to move the logic into the component rather than the template:
+```ts
+import { AbbyService } from '@tryabby/angular';
+
+@Component({...})
+export class MyComponent {
+  footerVariant$ = this.abbyService.getVariant('footer');
+
+  footerColor$ = this.footerVariant$.pipe(
+    map((footerVariant) => {
+      switch(footerVariant) {
+        case 'dark':
+          return 'black';
+        case 'orange': 
+          return 'orange';
+        case 'green':
+          return 'green';
+        default:
+          return 'transparent'
+      }
+    })
+  );
+
+  constructor(private abbyService: AbbyService) { }
+}
+```
+You can then consume the footer color in your template using the `async`-Pipe:
+```html
 <div
   class="footer"
-  [ngStyle]="{'color': footerVariant === 'dark' ? 'black' : 
-  footerVariant === 'orange' ? 'orange' : 
-  footerVariant === 'green' ? 'green'}"
+  [ngStyle]="{ 'color': footerColor$ | async }"
 >
   Here is a Foooter
 </div>

--- a/apps/web/src/components/AddFeatureFlagModal.tsx
+++ b/apps/web/src/components/AddFeatureFlagModal.tsx
@@ -54,7 +54,7 @@ export function ChangeFlagForm({
     const newState = { ...state, ...values };
 
     // if type changed, save the value
-    if (values.type != null && values.type !== state.type) {
+    if (values.type !== null && values.type !== state.type) {
       valueRef.current[state.type] = state.value;
       newState.value = valueRef.current[newState.type] ?? "";
     }

--- a/apps/web/src/components/DeleteProjectModal.tsx
+++ b/apps/web/src/components/DeleteProjectModal.tsx
@@ -46,7 +46,7 @@ export function DeleteProjectModal({ isOpen, onClose }: Props) {
       isOpen={isOpen}
       onClose={onClose}
       onConfirm={() => {
-        if (!projectId || status != "authenticated") return;
+        if (!projectId || status !== "authenticated") return;
         deleteProject({ projectId });
       }}
     >

--- a/apps/web/src/components/FeatureFlag.tsx
+++ b/apps/web/src/components/FeatureFlag.tsx
@@ -64,7 +64,7 @@ const HistoryButton = ({ flagValueId }: { flagValueId: string }) => {
             sideOffset={5}
           >
             {isLoading && <LoadingSpinner />}
-            {data != null && (
+            {data !== null && (
               <>
                 <p className="text-xs">Edited {data.length} times</p>
                 <hr className="-mx-2 my-1 border-gray-700" />

--- a/apps/web/src/components/FeatureFlag.tsx
+++ b/apps/web/src/components/FeatureFlag.tsx
@@ -64,7 +64,7 @@ const HistoryButton = ({ flagValueId }: { flagValueId: string }) => {
             sideOffset={5}
           >
             {isLoading && <LoadingSpinner />}
-            {data !== null && (
+            {data !== undefined && (
               <>
                 <p className="text-xs">Edited {data.length} times</p>
                 <hr className="-mx-2 my-1 border-gray-700" />

--- a/apps/web/src/lib/stripe.ts
+++ b/apps/web/src/lib/stripe.ts
@@ -50,7 +50,7 @@ export const isBetaPlan = (project: Project) =>
  */
 export const getProjectPaidPlan = <T extends Project>(project: T | null) => {
   // beta plans last for ever and have special rules
-  if (project != null && isBetaPlan(project)) return BETA_PRICE_ID;
+  if (project !== null && isBetaPlan(project)) return BETA_PRICE_ID;
 
   if (
     !project ||

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -23,7 +23,7 @@ export default withAuth(
         const pathName = req.nextUrl.pathname;
 
         // basic auth check for /profile
-        if (pathName === "/profile") return token != null;
+        if (pathName === "/profile") return token !== null;
 
         if (!pathName.startsWith("/projects")) return true;
         const projectId = req.nextUrl.pathname.split("/")[2];

--- a/apps/web/src/pages/api/dashboard/[projectId]/data.ts
+++ b/apps/web/src/pages/api/dashboard/[projectId]/data.ts
@@ -70,7 +70,7 @@ export default async function getWeightsHandler(
         return {
           name: flagValue.flag.name,
           isEnabled:
-            flagValue.flag.type === "BOOLEAN" ? value === true : value != null,
+            flagValue.flag.type === "BOOLEAN" ? value === true : value !== null,
         };
       }),
     } satisfies LegacyAbbyDataResponse;

--- a/apps/web/src/pages/projects/[projectId]/settings.tsx
+++ b/apps/web/src/pages/projects/[projectId]/settings.tsx
@@ -81,7 +81,7 @@ const SettingsPage: NextPageWithLayout = () => {
     );
   };
 
-  const isPlanWithStripe = projectPlan != null && projectPlan != "BETA";
+  const isPlanWithStripe = projectPlan !== null && projectPlan !== "BETA";
 
   return (
     <main className="space-y-8 text-pink-50">
@@ -144,8 +144,8 @@ const SettingsPage: NextPageWithLayout = () => {
                     Redeem Coupon
                   </DashboardButton>
                 </Link>
-                {data.project.stripeCustomerId != null &&
-                  projectPlan != null && (
+                {data.project.stripeCustomerId !== null &&
+                  projectPlan !== null && (
                     <button
                       className="text- ml-4 mr-auto mt-4 rounded-sm bg-blue-300 px-3"
                       onClick={async () => {
@@ -290,7 +290,7 @@ const SettingsPage: NextPageWithLayout = () => {
                 isPlanWithStripe ||
                 !user?.role ||
                 user.role !== ROLE.ADMIN ||
-                session.data?.user?.projectIds == null ||
+                session.data?.user?.projectIds === null ||
                 session.data?.user?.projectIds.length === 1
               }
               className="bg-red-600 py-2 font-medium hover:bg-red-600"
@@ -312,7 +312,7 @@ const SettingsPage: NextPageWithLayout = () => {
         </>
       )}
       <RemoveUserModal
-        isOpen={userToRemove != null}
+        isOpen={userToRemove !== null}
         onClose={() => setUserToRemove(null)}
         user={userToRemove ?? undefined}
       />

--- a/apps/web/src/pages/projects/[projectId]/tests/[testId].tsx
+++ b/apps/web/src/pages/projects/[projectId]/tests/[testId].tsx
@@ -84,7 +84,7 @@ const TestDetailPage: NextPageWithLayout = () => {
   const intervalParam = useQueryParam(INTERVAL_PARAM_NAME);
 
   const interval =
-    intervalParam !== null && isValidInterval(intervalParam)
+    intervalParam !== undefined && isValidInterval(intervalParam)
       ? intervalParam
       : INTERVALS[1].value;
 

--- a/apps/web/src/pages/projects/[projectId]/tests/[testId].tsx
+++ b/apps/web/src/pages/projects/[projectId]/tests/[testId].tsx
@@ -84,7 +84,7 @@ const TestDetailPage: NextPageWithLayout = () => {
   const intervalParam = useQueryParam(INTERVAL_PARAM_NAME);
 
   const interval =
-    intervalParam != null && isValidInterval(intervalParam)
+    intervalParam !== null && isValidInterval(intervalParam)
       ? intervalParam
       : INTERVALS[1].value;
 

--- a/apps/web/src/server/services/EventService.ts
+++ b/apps/web/src/server/services/EventService.ts
@@ -51,7 +51,7 @@ export abstract class EventService {
       return prisma.event.findMany({
         where: {
           testId,
-          ...(specialIntervalInMs != Infinity &&
+          ...(specialIntervalInMs !== Infinity &&
             timeInterval !== SpecialTimeInterval.DAY && {
               createdAt: {
                 gte: new Date(now - getMSFromSpecialTimeInterval(timeInterval)),

--- a/apps/web/src/server/trpc/router/coupons.ts
+++ b/apps/web/src/server/trpc/router/coupons.ts
@@ -28,7 +28,7 @@ export const couponRouter = router({
         },
       });
 
-      if (!code || code.redeemedAt != null) {
+      if (!code || code.redeemedAt !== null) {
         throw new TRPCError({ code: "NOT_FOUND" });
       }
 

--- a/packages/angular/src/lib/abby-logger.service.ts
+++ b/packages/angular/src/lib/abby-logger.service.ts
@@ -1,0 +1,22 @@
+import { Inject, Injectable } from "@angular/core";
+import { AbbyConfig } from "@tryabby/core";
+import { ABBY_CONFIG_TOKEN } from "./abby.module";
+
+@Injectable()
+export class AbbyLoggerService {
+  readonly LOGGER_SCOPE = 'ng.Abby';
+
+  constructor(@Inject(ABBY_CONFIG_TOKEN) private config: AbbyConfig) {}
+
+  log(...args: unknown[]): void {
+    if (this.config.debug) {
+      console.log(this.LOGGER_SCOPE, ...args);
+    }
+  }
+
+  warn(...args: unknown[]): void {
+    if (this.config.debug) {
+      console.warn(this.LOGGER_SCOPE, ...args);
+    }
+  }
+}

--- a/packages/angular/src/lib/abby.module.ts
+++ b/packages/angular/src/lib/abby.module.ts
@@ -1,11 +1,18 @@
-import { APP_INITIALIZER, InjectionToken, ModuleWithProviders, NgModule } from "@angular/core";
+import {
+  APP_INITIALIZER,
+  inject,
+  InjectionToken,
+  ModuleWithProviders,
+  NgModule,
+} from "@angular/core";
+import { AbbyConfig } from "@tryabby/core";
+import { firstValueFrom } from "rxjs";
+import { F } from "ts-toolbelt";
+import { AbbyLoggerService } from "./abby-logger.service";
 import { AbbyService } from "./abby.service";
-import { Abby, AbbyConfig } from "@tryabby/core";
+import { DevtoolsComponent } from "./devtools.component";
 import { AbbyFlag } from "./flag.directive";
 import { AbbyTest } from "./test.directive";
-import { DevtoolsComponent } from "./devtools.component";
-import { F } from "ts-toolbelt";
-import { firstValueFrom } from "rxjs";
 
 export const ABBY_CONFIG_TOKEN = new InjectionToken<AbbyConfig>("AbbyConfig");
 
@@ -19,13 +26,16 @@ export class AbbyModule {
       ngModule: AbbyModule,
       providers: [
         {
+          provide: AbbyLoggerService,
+        },
+        {
           provide: ABBY_CONFIG_TOKEN,
           useValue: config, // assuming 'config' is your configuration data
         },
         {
           provide: AbbyService,
           useFactory: (config: AbbyConfig) => {
-            return new AbbyService(config as F.Narrow<AbbyConfig>);
+            return new AbbyService(config as F.Narrow<AbbyConfig>, inject(AbbyLoggerService));
           },
           deps: [ABBY_CONFIG_TOKEN],
         },

--- a/packages/angular/src/lib/abby.module.ts
+++ b/packages/angular/src/lib/abby.module.ts
@@ -5,6 +5,7 @@ import { AbbyFlag } from "./flag.directive";
 import { AbbyTest } from "./test.directive";
 import { DevtoolsComponent } from "./devtools.component";
 import { F } from "ts-toolbelt";
+import { firstValueFrom } from "rxjs";
 
 export const ABBY_CONFIG_TOKEN = new InjectionToken<AbbyConfig>("AbbyConfig");
 
@@ -30,16 +31,7 @@ export class AbbyModule {
         },
         {
           provide: APP_INITIALIZER,
-          useFactory: (abby: AbbyService) => {
-            return (): Promise<any> => {
-              return new Promise((resolve, reject) => {
-                abby.init().subscribe({
-                  next: () => resolve("Initialization Successful."),
-                  error: (err) => reject(err),
-                });
-              });
-            };
-          },
+          useFactory: (abby: AbbyService) => () => firstValueFrom(abby.init()),
           deps: [AbbyService],
           multi: true,
         },

--- a/packages/angular/src/lib/abby.service.spec.ts
+++ b/packages/angular/src/lib/abby.service.spec.ts
@@ -90,11 +90,14 @@ describe("AbbyService", () => {
 
   @Component({
     template: `
-      <div *featureFlag="'flag1'">
+      <div *abbyFlag="'flag1'">
         <h1>Flag 1</h1>
       </div>
-      <div *featureFlag="'flag2'">
+      <div *abbyFlag="'flag2'">
         <h1>Flag 2</h1>
+      </div>
+      <div *abbyFlag="dynamicFlag">
+        <h4>Dynamic Flag</h4>
       </div>
       <div *abbyTest="{ testName: 'test2', variant: 'A' }">
         <h2>A</h2>
@@ -104,7 +107,9 @@ describe("AbbyService", () => {
       </div>
     `,
   })
-  class TestComponent {}
+  class TestComponent {
+    dynamicFlag = 'flag1';
+  }
 
   beforeAll(async () => {
     const fetchSpy = spyOn(window, "fetch");
@@ -128,8 +133,6 @@ describe("AbbyService", () => {
     service = TestBed.inject(AbbyService);
   });
 
-  beforeEach(() => {});
-
   it("should be created", () => {
     expect(service).toBeTruthy();
   });
@@ -150,7 +153,7 @@ describe("AbbyService", () => {
     });
   });
 
-  fit("should respect the default values for feature flags", () => {
+  it("should respect the default values for feature flags", () => {
     service.getFeatureFlagValue("defaultFlag").subscribe((value) => {
       expect(value).toEqual(false);
     });
@@ -265,5 +268,11 @@ describe("AbbyService", () => {
     if (testAElement) {
       expect(testAElement.textContent).toEqual("A");
     } else fail("querySelector is null");
+  });
+
+  it('evaluates flag directives with property bound values', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    let flagElement = compiled.querySelector("h4");
+    expect(flagElement?.textContent).toEqual('Dynamic Flag');
   });
 });

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -88,7 +88,6 @@ export class AbbyService<
 
   public init(): Observable<void> {
     return this.resolveData().pipe(
-      tap(() => {}),
       map(() => void 0)
     );
   }

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -98,7 +98,8 @@ export class AbbyService<
     return this.resolveData().pipe(
       map((data) => this.abby.getTestVariant(testName)),
       tap((variant) => (this.selectedVariants[testName as string] = variant)),
-      tap((variant) => this.abbyLogger.log(`getVariant(${testName as string}) =>`, variant))
+      tap((variant) => this.abbyLogger.log(`getVariant(${testName as string}) =>`, variant)),
+      shareReplay(1),
     );
   }
 
@@ -144,7 +145,8 @@ export class AbbyService<
           (!featureFlagValue && isFeatureFlagInverted) ||
           (featureFlagValue && !isFeatureFlagInverted)
         );
-      })
+      }),
+      shareReplay(1),
     );
   }
 

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -1,39 +1,42 @@
-import {
-  Directive,
-  Input,
-  OnInit,
-  TemplateRef,
-  ViewContainerRef,
-} from "@angular/core";
-
+import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
+import { Subject, takeUntil } from "rxjs";
 import { AbbyService } from "./abby.service";
 
 @Directive({
   selector: "[featureFlag]",
 })
-export class AbbyFlag implements OnInit {
+export class AbbyFlag implements OnInit, OnDestroy {
   @Input() featureFlag: string;
+
+  private _destroy$ = new Subject<void>();
 
   constructor(
     private readonly abby: AbbyService,
-
     private _viewContainer: ViewContainerRef,
     private _templateRef: TemplateRef<any>
   ) {}
 
   ngOnInit(): void {
-    let flagName: string;
-    if (this.featureFlag.startsWith("!"))
-      flagName = this.featureFlag.substring(1);
-    else flagName = this.featureFlag;
-    this.abby.getFeatureFlagValue(flagName).subscribe((value) => {
-      this._viewContainer.clear();
-      if (
-        (value && this.featureFlag[0] != "!") ||
-        (this.featureFlag[0] == "!" && !value)
-      ) {
-        this._viewContainer.createEmbeddedView(this._templateRef);
-      }
-    });
+    const flagName = this.featureFlag.startsWith("!")
+      ? this.featureFlag.substring(1)
+      : this.featureFlag;
+
+    this.abby
+      .getFeatureFlagValue(flagName)
+      .pipe(takeUntil(this._destroy$))
+      .subscribe((value) => {
+        this._viewContainer.clear();
+        if (
+          (value && this.featureFlag[0] != "!") || 
+          (this.featureFlag[0] == "!" && !value)
+        ) {
+          this._viewContainer.createEmbeddedView(this._templateRef);
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this._destroy$.next();
+    this._destroy$.complete();
   }
 }

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
+import { Directive, Input, OnDestroy, TemplateRef, ViewContainerRef } from "@angular/core";
 import { distinctUntilChanged, Subject, switchMap, takeUntil } from "rxjs";
 import { AbbyLoggerService } from "./abby-logger.service";
 import { AbbyService } from "./abby.service";
@@ -6,7 +6,7 @@ import { AbbyService } from "./abby.service";
 @Directive({
   selector: "[abbyFlag]",
 })
-export class AbbyFlag implements OnInit, OnDestroy {
+export class AbbyFlag implements OnDestroy {
   @Input()
   set abbyFlag(featureFlag: string) {
     // ensure featureFlag is a string to quit gracefully
@@ -26,9 +26,7 @@ export class AbbyFlag implements OnInit, OnDestroy {
     private readonly abbyLogger: AbbyLoggerService,
     private _viewContainer: ViewContainerRef,
     private _templateRef: TemplateRef<any>
-  ) {}
-
-  ngOnInit(): void {
+  ) {
     this.currentFlag$
       .pipe(
         switchMap((flagName) => this.abby.getFeatureFlagValue(flagName)),

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
-import { Subject, takeUntil, map, distinctUntilChanged, ReplaySubject, switchMap } from "rxjs";
+import { distinctUntilChanged, Subject, switchMap, takeUntil } from "rxjs";
 import { AbbyService } from "./abby.service";
 
 @Directive({
@@ -29,16 +29,7 @@ export class AbbyFlag implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.currentFlag$
       .pipe(
-        switchMap((flagName) => {
-          return this.abby
-            .getFeatureFlagValue(flagName.startsWith("!") ? flagName.slice(1) : flagName)
-            .pipe(
-              map(
-                (value) =>
-                  (value && flagName[0] !== "!") || (flagName[0] === "!" && !value)
-              )
-            );
-        }),
+        switchMap((flagName) => this.abby.getFeatureFlagValue(flagName)),
         distinctUntilChanged(),
         takeUntil(this.destroy$)
       )

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -4,11 +4,11 @@ import { AbbyLoggerService } from "./abby-logger.service";
 import { AbbyService } from "./abby.service";
 
 @Directive({
-  selector: "[featureFlag]",
+  selector: "[abbyFlag]",
 })
 export class AbbyFlag implements OnInit, OnDestroy {
   @Input()
-  set featureFlag(featureFlag: string) {
+  set abbyFlag(featureFlag: string) {
     // ensure featureFlag is a string to quit gracefully
     if (typeof featureFlag !== "string") {
       this.abbyLogger.warn(`Expected a string as featureFlag. Got ${featureFlag}`);

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -17,8 +17,8 @@ export class AbbyFlag implements OnInit, OnDestroy {
     this.currentFlag$.next(featureFlag);
   }
 
-  private currentFlag$ = new ReplaySubject<string>(1);
-  private _destroy$ = new Subject<void>();
+  private currentFlag$ = new Subject<string>();
+  private destroy$ = new Subject<void>();
 
   constructor(
     private readonly abby: AbbyService,
@@ -35,12 +35,12 @@ export class AbbyFlag implements OnInit, OnDestroy {
             .pipe(
               map(
                 (value) =>
-                  (value && flagName[0] != "!") || (flagName[0] == "!" && !value)
+                  (value && flagName[0] !== "!") || (flagName[0] === "!" && !value)
               )
             );
         }),
         distinctUntilChanged(),
-        takeUntil(this._destroy$)
+        takeUntil(this.destroy$)
       )
       .subscribe((visible) => {
         if (visible) {
@@ -52,7 +52,7 @@ export class AbbyFlag implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-    this._destroy$.next();
-    this._destroy$.complete();
+    this.destroy$.next();
+    this.destroy$.complete();
   }
 }

--- a/packages/angular/src/lib/flag.directive.ts
+++ b/packages/angular/src/lib/flag.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, Input, OnDestroy, OnInit, TemplateRef, ViewContainerRef } from "@angular/core";
 import { distinctUntilChanged, Subject, switchMap, takeUntil } from "rxjs";
+import { AbbyLoggerService } from "./abby-logger.service";
 import { AbbyService } from "./abby.service";
 
 @Directive({
@@ -9,8 +10,8 @@ export class AbbyFlag implements OnInit, OnDestroy {
   @Input()
   set featureFlag(featureFlag: string) {
     // ensure featureFlag is a string to quit gracefully
-    if(typeof featureFlag !== 'string') {
-      console.warn(`Expected a string as featureFlag. Got ${featureFlag}`);
+    if (typeof featureFlag !== "string") {
+      this.abbyLogger.warn(`Expected a string as featureFlag. Got ${featureFlag}`);
       return;
     }
 
@@ -22,6 +23,7 @@ export class AbbyFlag implements OnInit, OnDestroy {
 
   constructor(
     private readonly abby: AbbyService,
+    private readonly abbyLogger: AbbyLoggerService,
     private _viewContainer: ViewContainerRef,
     private _templateRef: TemplateRef<any>
   ) {}

--- a/packages/angular/src/lib/test.directive.ts
+++ b/packages/angular/src/lib/test.directive.ts
@@ -16,7 +16,7 @@ import { AbbyService } from "./abby.service";
 export class AbbyTest implements OnInit, OnDestroy {
   @Input() abbyTest: { testName: string; variant: string };
 
-  private _destroy$ = new Subject<void>();
+  private destroy$ = new Subject<void>();
 
   constructor(
     private readonly abby: AbbyService,
@@ -30,7 +30,7 @@ export class AbbyTest implements OnInit, OnDestroy {
       .pipe(
         map((selectedVariant) => selectedVariant === this.abbyTest.variant),
         distinctUntilChanged(),
-        takeUntil(this._destroy$)
+        takeUntil(this.destroy$)
       )
       .subscribe((visible) => {
         if(visible) {
@@ -42,7 +42,7 @@ export class AbbyTest implements OnInit, OnDestroy {
   }
 
     ngOnDestroy(): void {
-      this._destroy$.next();
-      this._destroy$.complete();
+      this.destroy$.next();
+      this.destroy$.complete();
     }
 }

--- a/packages/angular/src/lib/test.directive.ts
+++ b/packages/angular/src/lib/test.directive.ts
@@ -6,7 +6,7 @@ import {
   TemplateRef,
   ViewContainerRef,
 } from "@angular/core";
-import { Subject, takeUntil } from "rxjs";
+import { distinctUntilChanged, map, Subject, takeUntil } from "rxjs";
 
 import { AbbyService } from "./abby.service";
 
@@ -27,13 +27,16 @@ export class AbbyTest implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.abby
       .getVariant(this.abbyTest.testName)
-      .pipe(takeUntil(this._destroy$))
-      .subscribe((selectedVariant: string) => {
-        // Clear the viewContainer before creating a new view.
-        this._viewContainer.clear();
-
-        if (selectedVariant === this.abbyTest.variant) {
+      .pipe(
+        map((selectedVariant) => selectedVariant === this.abbyTest.variant),
+        distinctUntilChanged(),
+        takeUntil(this._destroy$)
+      )
+      .subscribe((visible) => {
+        if(visible) {
           this._viewContainer.createEmbeddedView(this._templateRef);
+        } else {
+          this._viewContainer.clear();
         }
       });
   }

--- a/packages/angular/src/lib/test.directive.ts
+++ b/packages/angular/src/lib/test.directive.ts
@@ -1,18 +1,22 @@
 import {
   Directive,
   Input,
+  OnDestroy,
   OnInit,
   TemplateRef,
   ViewContainerRef,
 } from "@angular/core";
+import { Subject, takeUntil } from "rxjs";
 
 import { AbbyService } from "./abby.service";
 
 @Directive({
   selector: "[abbyTest]",
 })
-export class AbbyTest implements OnInit {
+export class AbbyTest implements OnInit, OnDestroy {
   @Input() abbyTest: { testName: string; variant: string };
+
+  private _destroy$ = new Subject<void>();
 
   constructor(
     private readonly abby: AbbyService,
@@ -23,6 +27,7 @@ export class AbbyTest implements OnInit {
   ngOnInit(): void {
     this.abby
       .getVariant(this.abbyTest.testName)
+      .pipe(takeUntil(this._destroy$))
       .subscribe((selectedVariant: string) => {
         // Clear the viewContainer before creating a new view.
         this._viewContainer.clear();
@@ -32,4 +37,9 @@ export class AbbyTest implements OnInit {
         }
       });
   }
+
+    ngOnDestroy(): void {
+      this._destroy$.next();
+      this._destroy$.complete();
+    }
 }


### PR DESCRIPTION
- refactored Angular library and example application to not have any memory leaks
- fixed `featureFlag` and `abbyTest` directive always clearing the viewContainerRef even if the visibile state of the viewContainer does not change
- fixed the usage of `forkJoin` in the routing-module of the Angular example application. `forkJoin` only emits a value when all Observables have completed, but our Observables do not complete. Thus switched to `combineLatest` instead