### PR TITLE
feat(angular): get variants with lookup

### DIFF
--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -17,6 +17,18 @@
 >
   Test
 </h4>
+<h4
+  [ngStyle]="{
+    'color': 'AngularTest'
+      | getAbbyVariant: { A: 'blue', B: 'green', C: 'yellow', D: 'pink' }
+      | async
+  }"
+>
+  Variants Pipe
+</h4>
+
+<h4>Variants with Lookup Object</h4>
+<p>{{ variantWithLookup$ | async }}</p>
 
 <h3>Simple Feature Flag Service Demo</h3>
 <div>angularFlag = {{ angularFlag$ | async }}</div>
@@ -38,6 +50,7 @@
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'B'}">BBBBBB</ng-container>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'C'}">CCCCCC</ng-container>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'D'}">DDDDDD</ng-container>
+
 
 <!-- todo -->
 

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -51,7 +51,6 @@
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'C'}">CCCCCC</ng-container>
 <ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'D'}">DDDDDD</ng-container>
 
-
 <!-- todo -->
 
 <h3>Feature Flag live change Demo</h3>

--- a/apps/angular-example/src/app/app.component.ts
+++ b/apps/angular-example/src/app/app.component.ts
@@ -12,6 +12,13 @@ export class AppComponent {
   angularTest$ = this.abby.getVariant("AngularTest");
   angularFlag$ = this.abby.getFeatureFlagValue("AngularFlag");
 
+  variantWithLookup$ = this.abby.getVariant("AngularTest", {
+    A: 1,
+    B: 2,
+    C: 3,
+    D: 4,
+  });
+
   headerColor$ = this.angularTest$.pipe(
     map((angularTest) => {
       switch(angularTest) {

--- a/apps/docs/pages/integrations/angular.mdx
+++ b/apps/docs/pages/integrations/angular.mdx
@@ -140,3 +140,15 @@ You can then consume the footer color in your template using the `async`-Pipe:
   Here is a Foooter
 </div>
 ```
+
+### Using Abby Pipes
+
+You can use the `getAbbyVariant` Pipe in your template to get the active variant of an AB Test.
+```html
+<p>{ "MyTestName" | getAbbyVariant }</p>
+```
+
+Optionally, you can pass in a lookup object, to map your variants to a custom type:
+```html
+<p>{ "MyTestName" | getAbbyVariant: { A: 123, B: 456, C: 789 }</p>
+```

--- a/apps/docs/pages/integrations/angular.mdx
+++ b/apps/docs/pages/integrations/angular.mdx
@@ -145,10 +145,10 @@ You can then consume the footer color in your template using the `async`-Pipe:
 
 You can use the `getAbbyVariant` Pipe in your template to get the active variant of an AB Test.
 ```html
-<p>{ "MyTestName" | getAbbyVariant }</p>
+<p>{ "MyTestName" | getAbbyVariant | async }</p>
 ```
 
 Optionally, you can pass in a lookup object, to map your variants to a custom type:
 ```html
-<p>{ "MyTestName" | getAbbyVariant: { A: 123, B: 456, C: 789 }</p>
+<p>{ "MyTestName" | getAbbyVariant: { A: 123, B: 456, C: 789 } | async }</p>
 ```

--- a/packages/angular/src/lib/abby.module.ts
+++ b/packages/angular/src/lib/abby.module.ts
@@ -5,20 +5,21 @@ import {
   ModuleWithProviders,
   NgModule,
 } from "@angular/core";
-import { AbbyConfig } from "@tryabby/core";
 import { firstValueFrom } from "rxjs";
 import { F } from "ts-toolbelt";
 import { AbbyLoggerService } from "./abby-logger.service";
+import { AbbyConfig } from "@tryabby/core";
 import { AbbyService } from "./abby.service";
 import { DevtoolsComponent } from "./devtools.component";
 import { AbbyFlag } from "./flag.directive";
 import { AbbyTest } from "./test.directive";
+import { GetAbbyVariantPipe } from "./get-variant.pipe";
 
 export const ABBY_CONFIG_TOKEN = new InjectionToken<AbbyConfig>("AbbyConfig");
 
 @NgModule({
-  declarations: [AbbyFlag, AbbyTest, DevtoolsComponent],
-  exports: [AbbyFlag, AbbyTest, DevtoolsComponent],
+  declarations: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe],
+  exports: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe],
 })
 export class AbbyModule {
   static forRoot(config: AbbyConfig): ModuleWithProviders<AbbyModule> {

--- a/packages/angular/src/lib/abby.service.spec.ts
+++ b/packages/angular/src/lib/abby.service.spec.ts
@@ -85,7 +85,7 @@ export class Abby extends AbbyService<
 > {}
 
 describe("AbbyService", () => {
-  let service: AbbyService;
+  let service: Abby;
   let fixture: ComponentFixture<TestComponent>;
 
   @Component({
@@ -150,6 +150,12 @@ describe("AbbyService", () => {
   it("returns the correct variant", () => {
     service.getVariant("test2").subscribe((value: string) => {
       expect(value).toEqual("A");
+    });
+  });
+
+  it("uses lookup object when getting variant", () => {
+    service.getVariant("test2", { A: 1, B: 2 }).subscribe((value) => {
+      expect(value).toEqual(1);
     });
   });
 

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -39,7 +39,7 @@ type LocalData<FlagName extends string = string, TestName extends string = strin
 
 type PossibleFlagName<FlagName extends string> = FlagName | `!${FlagName}`;
 
-type ExtractVariants<
+export type ExtractVariants<
   TestName extends Key,
   Tests extends Record<TestName, ABConfig>,
 > = Tests[TestName]["variants"][number];

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -101,11 +101,11 @@ export class AbbyService<
   public getVariant<T extends keyof Tests>(testName: T): Observable<string>;
   public getVariant<T extends keyof Tests, S>(
     testName: T,
-    lookupObject: { [key in ExtractVariants<T, Tests>]: S }
+    lookupObject: { [key in ExtractVariants<T, Tests>]: S } | undefined
   ): Observable<S>;
   public getVariant<T extends keyof Tests, S>(
     testName: T,
-    lookupObject?: { [key in ExtractVariants<T, Tests>]: S }
+    lookupObject?: { [key in ExtractVariants<T, Tests>]: S } | undefined
   ): Observable<string | S> {
     this.abbyLogger.log(`getVariant(${testName as string})`);
 

--- a/packages/angular/src/lib/get-variant.pipe.spec.ts
+++ b/packages/angular/src/lib/get-variant.pipe.spec.ts
@@ -1,0 +1,74 @@
+import { fakeAsync, TestBed, tick } from "@angular/core/testing";
+import { AbbyModule } from "./abby.module";
+import { AbbyService } from "./abby.service";
+import { GetAbbyVariantPipe } from "./get-variant.pipe";
+import { TestStorageService } from "./StorageService";
+
+const mockConfig = {
+  projectId: "mock-project-id",
+  currentEnvironment: "test",
+  tests: {
+    test: {
+      variants: ["A"],
+    }
+  },
+  flags: {},
+  settings: {},
+} as const;
+
+const mockedData = {
+  tests: [
+    {
+      name: "test",
+      weights: [1],
+    },
+  ],
+  flags: [],
+};
+
+describe("GetAbbyVariantPipe", () => {
+  let pipe: GetAbbyVariantPipe<keyof (typeof mockConfig)["tests"], (typeof mockConfig)["tests"]>;
+  let service: AbbyService<
+    keyof (typeof mockConfig)["flags"],
+    keyof (typeof mockConfig)["tests"],
+    (typeof mockConfig)["tests"],
+    (typeof mockConfig)["flags"]
+  >;
+
+  let fetchSpy: any;
+
+  beforeAll(() => {
+    fetchSpy = spyOn(window, "fetch");
+
+    const mockedResponse = new Response(JSON.stringify(mockedData), {
+      status: 200,
+      headers: { "Content-type": "application/json" },
+    });
+
+    fetchSpy.and.returnValue(Promise.resolve(mockedResponse));
+
+    TestBed.configureTestingModule({
+      providers: [GetAbbyVariantPipe],
+      imports: [AbbyModule.forRoot(mockConfig)],
+    });
+
+    service = TestBed.inject(AbbyService);
+    pipe = TestBed.inject(GetAbbyVariantPipe);
+  });
+
+  it('creates pipe correctly', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it('returns currently active variant', () => {
+    pipe.transform("test").subscribe((value) => {
+      expect(value).toEqual("A");
+    });
+  });
+
+  it('uses lookup object when supplied', () => {
+    pipe.transform("test", { A: 123 }).subscribe((value) => {
+      expect(value).toEqual(123);
+    });
+  });
+});

--- a/packages/angular/src/lib/get-variant.pipe.ts
+++ b/packages/angular/src/lib/get-variant.pipe.ts
@@ -1,12 +1,13 @@
 import { Pipe, PipeTransform } from "@angular/core";
 import { ABConfig } from "@tryabby/core";
 import { Observable } from "rxjs";
+import { Key } from "ts-toolbelt/out/Any/Key";
 import { AbbyService, ExtractVariants } from "./abby.service";
 
 @Pipe({
   name: "getAbbyVariant",
 })
-export class GetAbbyVariantPipe<TestName extends string, Tests extends Record<TestName, ABConfig>>
+export class GetAbbyVariantPipe<TestName extends Key, Tests extends Record<TestName, ABConfig>>
   implements PipeTransform
 {
   constructor(private abbyService: AbbyService<string, string, Tests>) {}

--- a/packages/angular/src/lib/get-variant.pipe.ts
+++ b/packages/angular/src/lib/get-variant.pipe.ts
@@ -21,10 +21,6 @@ export class GetAbbyVariantPipe<TestName extends Key, Tests extends Record<TestN
     testName: TestName,
     lookupObject?: Record<ExtractVariants<TestName, Tests>, S>
   ): Observable<string | S> {
-    if (lookupObject === undefined) {
-      return this.abbyService.getVariant(testName);
-    }
-
     return this.abbyService.getVariant(testName, lookupObject);
   }
 }

--- a/packages/angular/src/lib/get-variant.pipe.ts
+++ b/packages/angular/src/lib/get-variant.pipe.ts
@@ -1,0 +1,29 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { ABConfig } from "@tryabby/core";
+import { Observable } from "rxjs";
+import { AbbyService, ExtractVariants } from "./abby.service";
+
+@Pipe({
+  name: "getAbbyVariant",
+})
+export class GetAbbyVariantPipe<TestName extends string, Tests extends Record<TestName, ABConfig>>
+  implements PipeTransform
+{
+  constructor(private abbyService: AbbyService<string, string, Tests>) {}
+
+  transform(testName: TestName): Observable<string>;
+  transform<S>(
+    testName: TestName,
+    lookupObject: Record<ExtractVariants<TestName, Tests>, S>
+  ): Observable<S>;
+  transform<S>(
+    testName: TestName,
+    lookupObject?: Record<ExtractVariants<TestName, Tests>, S>
+  ): Observable<string | S> {
+    if (lookupObject === undefined) {
+      return this.abbyService.getVariant(testName);
+    }
+
+    return this.abbyService.getVariant(testName, lookupObject);
+  }
+}

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -6,4 +6,5 @@ export * from "./lib/abby.service";
 export * from "./lib/abby.module";
 export * from "./lib/test.directive";
 export * from "./lib/flag.directive";
+export * from "./lib/get-variant.pipe";
 export * from "./lib/devtools.component";


### PR DESCRIPTION
- adds optional `lookupObject` parameter to `getVariant` call to lookup a variant in a map
- add pipe to get variant in the template (also with optional lookupObject)

The pipe can sadly not infer the types of Abby unless we pass the config as a parameter to it as well, which is unnecessary.
The function has full type checking