### PR TITLE
feat(libs): get variant with lookup

### DIFF
--- a/apps/angular-example/CHANGELOG.md
+++ b/apps/angular-example/CHANGELOG.md
@@ -1,5 +1,13 @@
 # angular-example
 
+## 0.0.9
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/angular@1.2.0
+  - @tryabby/devtools@4.1.0
+
 ## 0.0.8
 
 ### Patch Changes

--- a/apps/angular-example/package.json
+++ b/apps/angular-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-example",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/apps/docs/pages/integrations/react.mdx
+++ b/apps/docs/pages/integrations/react.mdx
@@ -102,6 +102,34 @@ function MyButton() {
 }
 ```
 
+Optionally, you can pass a lookup object to automatically map the selected variant to a custom value.
+```tsx
+import { useAbby } from "./abby";
+
+function MyButton() {
+  const { variant, onAct } = useAbby(
+    "footer",
+    {
+      dark: "bg-gray-900",
+      orange: "bg-orange-500",
+      green: "bg-green-500",
+    }
+  );
+
+  return (
+    <main className="p-6">
+      <h1>Abby Test Page:</h1>
+      <button
+        className={`rounded-lg py-2 px-4 text-white ${variant}`}
+        onClick={onAct}
+      >
+        Cool Button
+      </button>
+    </main>
+  );
+}
+```
+
 ### useFeatureFlag
 
 The `useFeatureFlag` hook returns a boolean value that indicates if the flag is active or not.

--- a/apps/docs/pages/integrations/svelte.mdx
+++ b/apps/docs/pages/integrations/svelte.mdx
@@ -116,7 +116,22 @@ The `useAbby` function returns an object with the following values:
 		<button on:click={onAct}> B</button>
 	{/if}
 </body>
+```
 
+Optionally, you can provide a lookup object to map the active to a custom value.
+```svelte
+<script lang="ts">
+    import { abby } from "$lib/abby";
+    const { variant , onAct } = abby.useAbby("test", {
+        A: "Hello",
+        B: "Goodbye"
+    });
+</script>
+
+<body>
+    <h1>Abby Test Page:</h1>
+    <p>{ variant } World!</p>
+</body>
 ```
 
 ## useFeatureFlag

--- a/apps/docs/pages/reference/angular.mdx
+++ b/apps/docs/pages/reference/angular.mdx
@@ -105,17 +105,21 @@ The settings property is an object containing additional settings for A/BBY. The
 
 - `AbbyService` is a angular service, which provides methods for getting
 
-### getVariant(testName: string)
+### getVariant(testName: string, lookupObject?)
 
 Resolves the selected variant for a given test name.
+Automatically maps the active variant to a custom value if `lookupObject` is provided.
 
 #### Parameters
 
-The name of the test, needs to be one of the defined tests.
+- `testName`: The name of the test, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 #### Return Value
 
 The variant of the test _Type: `string`_
+
+Or the custom value from the `lookupObject` when provided
 
 ### getFeatureFlagValue(flagName: string)
 
@@ -163,6 +167,31 @@ The name of the feature flag. The name can be prefixed with ! to invert the flag
 
 ```html
 <div *featureFlag="'test-flag'"></div>
+```
+
+## Pipes
+
+### getAbbyVariant Pipe
+
+Returns the active variant for an AB-Test.
+Automatically maps the active variant to a custom value if `lookupObject` is provided.
+
+#### Parameters
+
+- `testName`: The name of the test, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
+
+#### Example
+```html
+<h4
+  [ngStyle]="{
+    'color': 'AngularTest'
+      | getAbbyVariant: { A: 'blue', B: 'green', C: 'yellow', D: 'pink' }
+      | async
+  }"
+>
+  Variants Pipe
+</h4>
 ```
 
 ## Devtool Component

--- a/apps/docs/pages/reference/nextjs.mdx
+++ b/apps/docs/pages/reference/nextjs.mdx
@@ -79,11 +79,12 @@ New users will get a random value for a test depending on the defined weights
 
 ##### Parameters
 
-- `string`: The name of the test or flag, needs to be one of the defined tests.
+- `name`: The name of the test or flag, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-- `variant` : The variant of the test
+- `variant` : The variant of the test or the looked up value if you provided a `lookupObject`
 
 - `onAct`: A function to call when the user performs an action associated with the test _Type: `function`_
 
@@ -124,11 +125,12 @@ Otherwise the variant will be read from the cookie and returned.
 
 ##### Parameters
 
-The name of the test, needs to be one of the defined tests.
+- `testName`: The name of the test, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-The variant of the test.
+The variant of the test or the looked up value if you provided a `lookupObject`
 
 #### \_\_abby\_\_
 

--- a/apps/docs/pages/reference/react.mdx
+++ b/apps/docs/pages/reference/react.mdx
@@ -79,11 +79,12 @@ New users will get a random value for a test depending on the defined weights
 
 ##### Parameters
 
-- `string`: The name of the test or flag, needs to be one of the defined tests.
+- `testName`: The name of the test or flag, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-- `variant` : The variant of the test
+- `variant` : The variant of the test or the looked up value if you provided a `lookupObject`
 
 - `onAct`: A function to call when the user performs an action associated with the test _Type: `function`_
 
@@ -124,11 +125,12 @@ Otherwise the variant will be read from the cookie and returned.
 
 ##### Parameters
 
-The name of the test, needs to be one of the defined tests.
+- `testName`: The name of the test, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-The variant of the test.
+The variant of the test or the looked up value if you provided a `lookupObject`
 
 #### withDevtools
 

--- a/apps/docs/pages/reference/svelte.mdx
+++ b/apps/docs/pages/reference/svelte.mdx
@@ -79,11 +79,12 @@ New users will get a random value for a test depending on the defined weights
 
 ##### Parameters
 
-- `string`: The name of the test or flag, needs to be one of the defined tests.
+- `testName`: The name of the test or flag, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-- `variant` : Store providing the variant of the test
+- `variant`: Store providing the variant of the test or the looked up value if you provided a `lookupObject` 
 
 - `onAct`: A function to call when the user performs an action associated with the test _Type: `function`_
 
@@ -118,17 +119,18 @@ The name of the test or flag, needs to be one of the defined flags.
 
 #### getABTestValue
 
-`getABTestValue` is a function to access the users variant of an A/B Test. This can be called in a non-svelte scope.
+`getABTestValue` is a function to access the users variant of an A/B Test. This can be called in a non-react scope.
 If the user is new, a random variant will be generated based on the weights, persisted in a cookie and returned.
 Otherwise the variant will be read from the cookie and returned.
 
 ##### Parameters
 
-The name of the test, needs to be one of the defined tests.
+- `testName`: The name of the test, needs to be one of the defined tests.
+- `lookupObject`: An optional lookup object to automatically map the active variant to a custom value.
 
 ##### Return Values
 
-The variant of the test.
+The variant of the test or the looked up value if you provided a `lookupObject`
 
 #### \_\_abby\_\_
 

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # web
 
+## 0.2.27
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@4.2.0
+  - @tryabby/next@4.1.1
+  - @tryabby/devtools@4.1.0
+
 ## 0.2.26
 
 ### Patch Changes

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.2.26",
+  "version": "0.2.27",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/angular
 
+## 1.2.0
+
+### Minor Changes
+
+- add lookup object to useAbby and ab test value function
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@4.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/angular",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable } from "@angular/core";
 import { Route } from "@angular/router";
+import { ExtractVariants } from "@tryabby/core";
 import {
   Abby,
   AbbyConfig,
@@ -24,7 +25,6 @@ import {
 import { F } from "ts-toolbelt";
 import { AbbyLoggerService } from "./abby-logger.service";
 import { FlagStorageService, TestStorageService } from "./StorageService";
-import { Key } from "ts-toolbelt/out/Any/Key";
 
 type LocalData<FlagName extends string = string, TestName extends string = string> = {
   tests: Record<
@@ -47,11 +47,6 @@ export type InferTests<C extends AbbyConfig> = NonNullable<C["tests"]>;
 export type InferFlags<C extends AbbyConfig> = NonNullable<C["flags"]>;
 
 type PossibleFlagName<FlagName extends string> = FlagName | `!${FlagName}`;
-
-export type ExtractVariants<
-  TestName extends Key,
-  Tests extends Record<TestName, ABConfig>,
-> = Tests[TestName]["variants"][number];
 
 @Injectable({ providedIn: "root" })
 export class AbbyService<

--- a/packages/angular/src/lib/get-variant.pipe.ts
+++ b/packages/angular/src/lib/get-variant.pipe.ts
@@ -1,8 +1,8 @@
 import { Pipe, PipeTransform } from "@angular/core";
-import { ABConfig } from "@tryabby/core";
+import { ABConfig, ExtractVariants } from "@tryabby/core";
 import { Observable } from "rxjs";
 import { Key } from "ts-toolbelt/out/Any/Key";
-import { AbbyService, ExtractVariants } from "./abby.service";
+import { AbbyService } from "./abby.service";
 
 @Pipe({
   name: "getAbbyVariant",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tryabby/core
 
+## 4.2.0
+
+### Minor Changes
+
+- add lookup object to useAbby and ab test value function
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/core",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -1,3 +1,5 @@
+import { Key } from "ts-toolbelt/out/Any/Key";
+import { ABConfig } from "..";
 import { FlagValue } from "./schemas";
 
 export enum AbbyEventType {
@@ -23,3 +25,9 @@ export type LegacyAbbyDataResponse = {
   }>;
   flags: Array<{ name: string; isEnabled: boolean }>;
 };
+
+export type ExtractVariants<
+  TestName extends Key,
+  Tests extends Record<TestName, ABConfig>,
+> = Tests[TestName]["variants"][number];
+

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @tryabby/next
 
+## 4.1.1
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/react@4.2.0
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/next",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/next/src/index.tsx
+++ b/packages/next/src/index.tsx
@@ -3,6 +3,7 @@ import {
   ABConfig,
   createAbby as baseCreateAbby,
   withDevtoolsFunction,
+  ABTestReturnValue,
 } from "@tryabby/react";
 import { AbbyDataResponse, FlagValueString, getABStorageKey } from "@tryabby/core";
 import type { F } from "ts-toolbelt";
@@ -48,7 +49,21 @@ export function createAbby<
 
   return {
     AbbyProvider,
-    useAbby,
+    // we need to retype the useAbby function here
+    // because re-using the types from the react package causes the ts-toolbelt package to behave weirdly
+    // and therefore not working as expected
+    useAbby: useAbby as <
+      K extends keyof Tests,
+      TestVariant extends Tests[K]["variants"][number],
+      LookupValue,
+      Lookup extends Record<TestVariant, LookupValue> | undefined = undefined,
+    >(
+      name: K,
+      lookupObject?: F.Narrow<Lookup>
+    ) => {
+      variant: ABTestReturnValue<Lookup, TestVariant>;
+      onAct: () => void;
+    },
     useFeatureFlag,
     withAbby: withAbby(config as AbbyConfig<FlagName, Tests>, __abby__),
     getFeatureFlagValue,

--- a/packages/next/tests/useAbby.test.tsx
+++ b/packages/next/tests/useAbby.test.tsx
@@ -64,4 +64,27 @@ describe("useAbby", () => {
 
     expectTypeOf(ff2Result.current).toEqualTypeOf<string>();
   });
+
+  it("uses lookup object when retrieving AB test variant", () => {
+    const { getABTestValue } = createAbby({
+      projectId: "123",
+      tests: {
+        test2: {
+          variants: ["SimonsText", "MatthiasText", "TomsText", "TimsText"],
+        },
+      },
+    });
+
+    const lookupMap = {
+      SimonsText: "a",
+      MatthiasText: "b",
+      TomsText: "c",
+      TimsText: "d",
+    };
+
+    const activeVariant = getABTestValue("test2")[0];
+    const value = getABTestValue("test2", undefined, lookupMap)[0];
+
+    expect(value).toBe(lookupMap[activeVariant]);
+  });
 });

--- a/packages/next/tests/useAbby.test.tsx
+++ b/packages/next/tests/useAbby.test.tsx
@@ -42,7 +42,7 @@ describe("useAbby", () => {
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
 
-    expectTypeOf(useAbby).parameters.toEqualTypeOf<["test" | "test2"]>();
+    expectTypeOf(useAbby).parameter(0).toEqualTypeOf<"test" | "test2">();
 
     const { result } = renderHook(() => useAbby("test"), {
       wrapper,
@@ -67,6 +67,7 @@ describe("useAbby", () => {
 
   it("uses lookup object when retrieving AB test variant", () => {
     const { getABTestValue } = createAbby({
+      environments: [],
       projectId: "123",
       tests: {
         test2: {
@@ -86,5 +87,54 @@ describe("useAbby", () => {
     const value = getABTestValue("test2", undefined, lookupMap)[0];
 
     expect(value).toBe(lookupMap[activeVariant]);
+  });
+
+  it("produces proper types with a lookup objects", () => {
+    const { getABTestValue } = createAbby({
+      environments: [],
+      projectId: "123",
+      currentEnvironment: "a",
+      tests: {
+        test: {
+          variants: ["A", "B", "C"],
+        },
+      },
+    });
+
+    const [activeVariant] = getABTestValue("test", undefined, {
+      A: "Hello",
+      B: "Bonjour",
+      C: "Hola",
+    });
+
+    expectTypeOf(activeVariant).toEqualTypeOf<"Hello" | "Bonjour" | "Hola">();
+  });
+
+  it("produces proper types with a a lookup object in the hook", () => {
+    const { AbbyProvider, useAbby } = createAbby({
+      environments: [],
+      projectId: "123",
+      tests: {
+        test: {
+          variants: ["A", "B", "C"],
+        },
+      },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
+
+    const { result } = renderHook(
+      () =>
+        useAbby("test", {
+          A: "Hello",
+          B: "Bonjour",
+          C: "Hola",
+        }),
+      {
+        wrapper,
+      }
+    );
+
+    expectTypeOf(result.current.variant).toEqualTypeOf<"Hello" | "Bonjour" | "Hola">();
   });
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/react
 
+## 4.2.0
+
+### Minor Changes
+
+- add lookup object to useAbby and ab test value function
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@4.2.0
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/react",
-  "version": "4.1.0",
+  "version": "4.2.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -13,7 +13,7 @@ export type withDevtoolsFunction = (
   }
 ) => () => JSX.Element | null;
 
-type ABTestReturnValue<Lookup, TestVariant> = Lookup extends undefined
+export type ABTestReturnValue<Lookup, TestVariant> = Lookup extends undefined
   ? TestVariant
   : TestVariant extends keyof Lookup
   ? Lookup[TestVariant]
@@ -75,7 +75,7 @@ export function createAbby<
     LookupValue,
     Lookup extends Record<TestVariant, LookupValue> | undefined = undefined,
   >(
-    name: TestName,
+    name: K,
     lookupObject?: F.Narrow<Lookup>
   ): {
     variant: ABTestReturnValue<Lookup, TestVariant>;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,2 @@
-export { createAbby, type withDevtoolsFunction } from "./context";
+export { createAbby, type withDevtoolsFunction, type ABTestReturnValue } from "./context";
 export { type ABConfig, type AbbyConfig, defineConfig } from "@tryabby/core";

--- a/packages/react/tests/useAbby.test.tsx
+++ b/packages/react/tests/useAbby.test.tsx
@@ -72,6 +72,32 @@ describe("useAbby", () => {
     expect(result.current.variant).toEqual(persistedValue);
   });
 
+  it("looks up the selected variant in the lookup object", () => {
+    const persistedValue = "SimonsText";
+    const variants = ["SimonsText", "MatthiasText", "TomsText", "TimsText"] as const;
+
+    const getSpy = vi.spyOn(TestStorageService, "get");
+    getSpy.mockReturnValue(persistedValue);
+
+    const { AbbyProvider, useAbby } = createAbby({
+      projectId: "123",
+      tests: {
+        test: { variants },
+      },
+    });
+
+    const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
+    const { result } = renderHook(
+      () => useAbby("test", { SimonsText: "a", MatthiasText: "b", TomsText: "c", TimsText: "d" }),
+      {
+        wrapper,
+      }
+    );
+
+    // value set in localstorage
+    expect(result.current.variant).toEqual("a");
+  });
+
   it("should ping the current info on mount", () => {
     const spy = vi.spyOn(HttpService, "sendData");
     const { AbbyProvider, useAbby } = createAbby({
@@ -254,7 +280,7 @@ describe("useAbby", () => {
       A: 1,
       B: 2,
       C: 3,
-    }
+    };
 
     expect(getABTestValue("test", lookupObject)).toEqual(lookupObject[activeVariant]);
   });

--- a/packages/react/tests/useAbby.test.tsx
+++ b/packages/react/tests/useAbby.test.tsx
@@ -237,4 +237,25 @@ describe("useAbby", () => {
     });
     expect(getVariants("test")).toEqual(["A", "B", "C"]);
   });
+
+  it("uses the lookup object when retrieving a variant", () => {
+    const { getABTestValue } = createAbby({
+      projectId: "123",
+      currentEnvironment: "a",
+      tests: {
+        test: {
+          variants: ["A", "B", "C"],
+        },
+      },
+    });
+
+    const activeVariant = getABTestValue("test");
+    const lookupObject = {
+      A: 1,
+      B: 2,
+      C: 3,
+    }
+
+    expect(getABTestValue("test", lookupObject)).toEqual(lookupObject[activeVariant]);
+  });
 });

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/svelte
 
+## 1.2.0
+
+### Minor Changes
+
+- add lookup object to useAbby and ab test value function
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@4.2.0
+
 ## 1.1.0
 
 ### Minor Changes

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tryabby/svelte",
-	"version": "1.1.0",
+	"version": "1.2.0",
 	"main": "dist/index.umd.cjs",
 	"homepage": "https://docs.tryabby.dev",
 	"type": "module",

--- a/packages/svelte/src/lib/createAbby.ts
+++ b/packages/svelte/src/lib/createAbby.ts
@@ -1,22 +1,17 @@
-import {
-  Abby,
-  type AbbyConfig,
-  type ABConfig,
-  type ExtractVariants,
-  type FlagValueString,
-} from "@tryabby/core";
+import { Abby, type AbbyConfig, type ABConfig, type FlagValueString } from "@tryabby/core";
 import { HttpService, AbbyEventType } from "@tryabby/core";
-import { derived, get } from "svelte/store";
+import { derived, type Readable } from "svelte/store";
 import type { F } from "ts-toolbelt";
 // import type { LayoutServerLoad, LayoutServerLoadEvent } from "../routes/$types"; TODO fix import
 import { FlagStorageService, TestStorageService } from "./StorageService";
 import AbbyProvider from "./AbbyProvider.svelte";
 import AbbyDevtools from "./AbbyDevtools.svelte";
 
-type GetABTestValue<TestName extends string, Tests extends Record<TestName, ABConfig>> = {
-  (testName: TestName): string;
-  <S>(testName: TestName, lookupObject: Record<ExtractVariants<TestName, Tests>, S>): S;
-};
+type ABTestReturnValue<Lookup, TestVariant> = Lookup extends undefined
+  ? TestVariant
+  : TestVariant extends keyof Lookup
+  ? Lookup[TestVariant]
+  : never;
 
 export function createAbby<
   FlagName extends string,
@@ -68,14 +63,27 @@ export function createAbby<
     });
   };
 
-  const useAbby = <K extends keyof Tests>(testName: K) => {
-    const variant = derived<any, string>(abby, ($v) => {
-      return abby.getTestVariant(testName);
-    });
+  const useAbby = <
+    TestName extends keyof Tests,
+    TestVariant extends Tests[TestName]["variants"][number],
+    LookupValue,
+    Lookup extends Record<TestVariant, LookupValue> | undefined = undefined
+  >(
+    testName: TestName,
+    lookupObject?: F.Narrow<Lookup>
+  ): {
+    variant: Readable<ABTestReturnValue<Lookup, TestVariant>>;
+    onAct: () => void;
+  } => {
     let selectedVariant: string = "";
-    variant.subscribe((data) => {
-      selectedVariant = data;
+    const variant = derived<any, ABTestReturnValue<Lookup, TestVariant>>(abby, ($v) => {
+      selectedVariant = abby.getTestVariant(testName);
+      return lookupObject ? lookupObject[selectedVariant] : selectedVariant;
     });
+
+    // ensure side effect is triggered
+    variant.subscribe(() => {});
+
     const onAct = () => {
       HttpService.sendData({
         url: config.apiUrl,
@@ -88,6 +96,7 @@ export function createAbby<
       });
     };
     notify(testName, selectedVariant);
+
     return { variant, onAct };
   };
 
@@ -114,15 +123,11 @@ export function createAbby<
   >(
     testName: TestName,
     lookupObject?: F.Narrow<Lookup>
-  ): Lookup extends undefined
-      ? TestVariant
-      : TestVariant extends keyof Lookup
-      ? Lookup[TestVariant]
-      : never => {
+  ): ABTestReturnValue<Lookup, TestVariant> => {
     const variant = abby.getTestVariant(testName);
     // Typescript looses its typing here, so we cast as any in favor of having
     // better type inference for the user
-    if(lookupObject === undefined) {
+    if (lookupObject === undefined) {
       return variant as any;
     }
 

--- a/packages/svelte/src/lib/createAbby.ts
+++ b/packages/svelte/src/lib/createAbby.ts
@@ -1,11 +1,22 @@
-import { Abby, type AbbyConfig, type ABConfig, type FlagValueString } from "@tryabby/core";
+import {
+  Abby,
+  type AbbyConfig,
+  type ABConfig,
+  type ExtractVariants,
+  type FlagValueString,
+} from "@tryabby/core";
 import { HttpService, AbbyEventType } from "@tryabby/core";
-import { derived } from "svelte/store";
+import { derived, get } from "svelte/store";
 import type { F } from "ts-toolbelt";
 // import type { LayoutServerLoad, LayoutServerLoadEvent } from "../routes/$types"; TODO fix import
 import { FlagStorageService, TestStorageService } from "./StorageService";
 import AbbyProvider from "./AbbyProvider.svelte";
 import AbbyDevtools from "./AbbyDevtools.svelte";
+
+type GetABTestValue<TestName extends string, Tests extends Record<TestName, ABConfig>> = {
+  (testName: TestName): string;
+  <S>(testName: TestName, lookupObject: Record<ExtractVariants<TestName, Tests>, S>): S;
+};
 
 export function createAbby<
   FlagName extends string,
@@ -95,8 +106,27 @@ export function createAbby<
     };
   };
 
-  const getABTestValue = <T extends keyof Tests>(testName: T) => {
-    return abby.getTestVariant(testName);
+  const getABTestValue = <
+    TestName extends keyof Tests,
+    TestVariant extends Tests[TestName]["variants"][number],
+    LookupValue,
+    Lookup extends Record<TestVariant, LookupValue> | undefined = undefined
+  >(
+    testName: TestName,
+    lookupObject?: F.Narrow<Lookup>
+  ): Lookup extends undefined
+      ? TestVariant
+      : TestVariant extends keyof Lookup
+      ? Lookup[TestVariant]
+      : never => {
+    const variant = abby.getTestVariant(testName);
+    // Typescript looses its typing here, so we cast as any in favor of having
+    // better type inference for the user
+    if(lookupObject === undefined) {
+      return variant as any;
+    }
+
+    return lookupObject[variant as keyof typeof lookupObject] as any;
   };
 
   const getFeatureFlagValue = <F extends keyof Flags>(featureFlagName: F) => {

--- a/packages/svelte/src/tests/useAbby.test.ts
+++ b/packages/svelte/src/tests/useAbby.test.ts
@@ -51,6 +51,30 @@ describe("useAbby working", () => {
     expect(result).toEqual(persistedValue);
   });
 
+  it("should look up the return value", () => {
+    const persistedValue = "SimonsText";
+    const variants = ["SimonsText", "MatthiasText", "TomsText", "TimsText"] as const;
+
+    const getSpy = vi.spyOn(TestStorageService, "get");
+
+    getSpy.mockReturnValue(persistedValue);
+    const { useAbby } = createAbby({
+      projectId: "123",
+      tests: {
+        test: { variants },
+      },
+    });
+
+    const { variant } = useAbby("test", {
+      SimonsText: "a",
+      MatthiasText: "b",
+      TomsText: "c",
+      TimsText: "d",
+    });
+    const result = get(variant);
+    expect(result).toBe("a");
+  });
+
   it("should ping the current info on mount", () => {
     const spy = vi.spyOn(HttpService, "sendData");
     const { useAbby } = createAbby({
@@ -108,12 +132,7 @@ describe("useAbby working", () => {
       projectId: "123",
       tests: {
         lookupTest: {
-          variants: [
-            "SimonsText",
-            "MatthiasText",
-            "TomsText",
-            "TimsText",
-          ],
+          variants: ["SimonsText", "MatthiasText", "TomsText", "TimsText"],
         },
       },
     } as const);

--- a/packages/svelte/src/tests/useAbby.test.ts
+++ b/packages/svelte/src/tests/useAbby.test.ts
@@ -1,9 +1,10 @@
 import { TestStorageService } from "../lib/StorageService";
-import { HttpService, AbbyEventType } from "@tryabby/core";
+import { HttpService, AbbyEventType, getABStorageKey } from "@tryabby/core";
 import { createAbby } from "../lib/createAbby";
 import { it, describe, expect, afterEach, vi, beforeAll, afterAll } from "vitest";
 /// @ts-ignore it doesn't have types
 import { get } from "svelte/store";
+import Cookies from "js-cookie";
 
 const OLD_ENV = process.env;
 
@@ -100,5 +101,32 @@ describe("useAbby working", () => {
     });
     const recievedVariants = get(getVariants("test"));
     expect(recievedVariants).toEqual(expectedVariants);
+  });
+
+  it("uses lookup object when retrieving variant", async () => {
+    const { getABTestValue } = createAbby({
+      projectId: "123",
+      tests: {
+        lookupTest: {
+          variants: [
+            "SimonsText",
+            "MatthiasText",
+            "TomsText",
+            "TimsText",
+          ],
+        },
+      },
+    } as const);
+
+    const pickedVariant = getABTestValue("lookupTest");
+    const lookupMap = {
+      SimonsText: 1,
+      MatthiasText: 2,
+      TomsText: 3,
+      TimsText: 4,
+    };
+
+    const value = getABTestValue("lookupTest", lookupMap);
+    expect(value).toBe(lookupMap[pickedVariant]);
   });
 });

--- a/packages/svelte/src/tests/useAbby.test.ts
+++ b/packages/svelte/src/tests/useAbby.test.ts
@@ -59,6 +59,7 @@ describe("useAbby working", () => {
 
     getSpy.mockReturnValue(persistedValue);
     const { useAbby } = createAbby({
+      environments: [],
       projectId: "123",
       tests: {
         test: { variants },
@@ -129,13 +130,14 @@ describe("useAbby working", () => {
 
   it("uses lookup object when retrieving variant", async () => {
     const { getABTestValue } = createAbby({
+      environments: [],
       projectId: "123",
       tests: {
         lookupTest: {
           variants: ["SimonsText", "MatthiasText", "TomsText", "TimsText"],
         },
       },
-    } as const);
+    });
 
     const pickedVariant = getABTestValue("lookupTest");
     const lookupMap = {


### PR DESCRIPTION
Adds an optional `lookupObject` parameter to all methods, which retrieve an AB testvalue.