### PR TITLE
feat(web): restructure feature flags vs remote config

### DIFF
--- a/apps/angular-example/CHANGELOG.md
+++ b/apps/angular-example/CHANGELOG.md
@@ -1,5 +1,13 @@
 # angular-example
 
+## 0.0.10
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/devtools@5.0.0
+  - @tryabby/angular@2.0.0
+
 ## 0.0.9
 
 ### Patch Changes

--- a/apps/angular-example/abby.config.ts
+++ b/apps/angular-example/abby.config.ts
@@ -13,7 +13,10 @@ export default defineConfig({
       variants: ["A", "B"],
     },
   },
-  flags: { AngularFlag: "Boolean", AngularFlag2: "Boolean", NotExistingFlag: "Boolean" },
+  flags: ["AngularFlag", "AngularFlag2", "NotExistingFlag"],
+  remoteConfig: {
+    angularRemoteConfig: "String",
+  },
   apiUrl: "http://localhost:3000/",
   debug: true,
 });

--- a/apps/angular-example/angular.json
+++ b/apps/angular-example/angular.json
@@ -157,5 +157,8 @@
       }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/apps/angular-example/package.json
+++ b/apps/angular-example/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-example",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "private": true,
   "scripts": {
     "ng": "ng",

--- a/apps/angular-example/src/app/abby.ts
+++ b/apps/angular-example/src/app/abby.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { AbbyService, InferFlagNames, InferFlags, InferTestNames, InferTests } from "abby";
+import { AbbyService, InferFlagNames, InferTestNames, InferTests } from "abby";
 import abby from "../../abby.config";
 
 @Injectable({
@@ -9,6 +9,5 @@ import abby from "../../abby.config";
 export class Abby extends AbbyService<
   InferFlagNames<typeof abby>,
   InferTestNames<typeof abby>,
-  InferTests<typeof abby>,
-  InferFlags<typeof abby>
+  InferTests<typeof abby>
 > {}

--- a/apps/angular-example/src/app/abby.ts
+++ b/apps/angular-example/src/app/abby.ts
@@ -1,5 +1,12 @@
 import { Injectable } from "@angular/core";
-import { AbbyService, InferFlagNames, InferTestNames, InferTests } from "abby";
+import {
+  AbbyService,
+  InferFlagNames,
+  InferRemoteConfig,
+  InferRemoteConfigName,
+  InferTestNames,
+  InferTests,
+} from "abby";
 import abby from "../../abby.config";
 
 @Injectable({
@@ -9,5 +16,7 @@ import abby from "../../abby.config";
 export class Abby extends AbbyService<
   InferFlagNames<typeof abby>,
   InferTestNames<typeof abby>,
-  InferTests<typeof abby>
+  InferTests<typeof abby>,
+  InferRemoteConfig<typeof abby>,
+  InferRemoteConfigName<typeof abby>
 > {}

--- a/apps/angular-example/src/app/app.component.html
+++ b/apps/angular-example/src/app/app.component.html
@@ -6,22 +6,17 @@
 <button (click)="onAct()">OnAct</button>
 
 <h3>Simple Variant-Test Directive Demo with 4 options</h3>
-<ng-container *abbyTest="{testName: 'AngularTest', variant: 'A'}">AAAAAA</ng-container>
-<ng-container *abbyTest="{testName: 'AngularTest', variant: 'B'}">BBBBBB</ng-container>
-<ng-container *abbyTest="{testName: 'AngularTest', variant: 'C'}">CCCCCC</ng-container>
-<ng-container *abbyTest="{testName: 'AngularTest', variant: 'D'}">DDDDDD</ng-container>
+<ng-container *abbyTest="{ testName: 'AngularTest', variant: 'A' }">AAAAAA</ng-container>
+<ng-container *abbyTest="{ testName: 'AngularTest', variant: 'B' }">BBBBBB</ng-container>
+<ng-container *abbyTest="{ testName: 'AngularTest', variant: 'C' }">CCCCCC</ng-container>
+<ng-container *abbyTest="{ testName: 'AngularTest', variant: 'D' }">DDDDDD</ng-container>
 
-<h4
-  *ngIf="angularTest$ | async as angularTest"
-  [ngStyle]="{'color': headerColor$ | async }"
->
+<h4 *ngIf="angularTest$ | async as angularTest" [ngStyle]="{ color: headerColor$ | async }">
   Test
 </h4>
 <h4
   [ngStyle]="{
-    'color': 'AngularTest'
-      | getAbbyVariant: { A: 'blue', B: 'green', C: 'yellow', D: 'pink' }
-      | async
+    color: 'AngularTest' | getAbbyVariant: { A: 'blue', B: 'green', C: 'yellow', D: 'pink' } | async
   }"
 >
   Variants Pipe
@@ -39,17 +34,17 @@
 <div *abbyFlag="'!AngularFlag'">AngularFlag = OFF</div>
 
 <h3>Config UI Tool Demo</h3>
-<abby-devtools [props]="{dangerouslyForceShow: true}"></abby-devtools>
+<abby-devtools [props]="{ dangerouslyForceShow: true }"></abby-devtools>
 
 <h3>Default usage Demo</h3>
 <h4>Feature Flag</h4>
 <div *abbyFlag="'!NotExistingFlag'">AngularFlag = OFF</div>
 
 <h4>Variants</h4>
-<ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'A'}">AAAAAA</ng-container>
-<ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'B'}">BBBBBB</ng-container>
-<ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'C'}">CCCCCC</ng-container>
-<ng-container *abbyTest="{testName: 'NotExistingTest', variant: 'D'}">DDDDDD</ng-container>
+<ng-container *abbyTest="{ testName: 'NotExistingTest', variant: 'A' }">AAAAAA</ng-container>
+<ng-container *abbyTest="{ testName: 'NotExistingTest', variant: 'B' }">BBBBBB</ng-container>
+<ng-container *abbyTest="{ testName: 'NotExistingTest', variant: 'C' }">CCCCCC</ng-container>
+<ng-container *abbyTest="{ testName: 'NotExistingTest', variant: 'D' }">DDDDDD</ng-container>
 
 <!-- todo -->
 
@@ -66,7 +61,7 @@
 <h3>Router A/B Test Demo</h3>
 <nav>
   <ul>
-    <li><a [routerLink]="[{outlets: {test: 'test'}}]">Test</a></li>
+    <li><a [routerLink]="[{ outlets: { test: 'test' } }]">Test</a></li>
   </ul>
 </nav>
 <router-outlet name="test"></router-outlet>
@@ -75,7 +70,7 @@
 <div *abbyFlag="'AngularFlag'">
   <nav>
     <ul>
-      <li><a [routerLink]="[{outlets: {flag: 'flag'}}]">Feature</a></li>
+      <li><a [routerLink]="[{ outlets: { flag: 'flag' } }]">Feature</a></li>
     </ul>
   </nav>
 </div>
@@ -84,10 +79,13 @@
 <h3>Lazy-loaded module Demo</h3>
 <nav>
   <ul>
-    <li><a [routerLink]="[{outlets: {lazy: 'lazy'}}]">Lazy</a></li>
+    <li><a [routerLink]="[{ outlets: { lazy: 'lazy' } }]">Lazy</a></li>
   </ul>
 </nav>
 <router-outlet name="lazy"></router-outlet>
+
+<h3>Remote Config</h3>
+<p>angularRemoteConfig: {{ "angularRemoteConfig" | getAbbyRemoteConfig | async }}</p>
 
 <h3>Angular Universal SSR Demo</h3>
 <!-- todo -->

--- a/apps/angular-example/src/app/app.module.ts
+++ b/apps/angular-example/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { ReactiveFormsModule } from "@angular/forms";
     BrowserModule,
     AppRoutingModule,
     AbbyModule.forRoot(abbyConfig),
+    ReactiveFormsModule,
   ],
   providers: [],
 

--- a/apps/docs/pages/_meta.json
+++ b/apps/docs/pages/_meta.json
@@ -14,6 +14,7 @@
   },
   "a-b-testing": "A/B Tests",
   "feature-flags": "Feature Flags",
+  "remote-config": "Remote Configuration",
   "environments": "Environments",
   "config": "Configuration as Code",
   "-- More --": {

--- a/apps/docs/pages/config.mdx
+++ b/apps/docs/pages/config.mdx
@@ -56,23 +56,29 @@ export default defineConfig({
       variants: ["A", "B"],
     },
   },
-  flags: {
-    AdvancedTestStats: "JSON",
-    showFooter: "Boolean",
+  flags: ['showFooter'],
+  remoteConfig: {
+    customButtonText: "String",
     maxUserCount: "Number",
+    AdvancedTestStats: "JSON",
   },
   settings: {
     flags: {
+      defaultValue: false,
+      devOverrides: {
+        showFooter: true,
+      },
+    },
+    remoteConfig: {
       defaultValues: {
-        Boolean: false,
         JSON: {},
         Number: 0,
         String: "",
       },
       devOverrides: {
-        AdvancedTestStats: {},
-        showFooter: true,
         maxUserCount: 40,
+        AdvancedTestStats: {},
+        customButtonText: "My cool button",
       },
     },
   },
@@ -83,14 +89,15 @@ export default defineConfig({
 
 The `defineCOnfig` function takes an object as a parameter. The object can contain the following properties:
 
-| Name               | Type     | Required | Description                                             | details               |
-| ------------------ | -------- | :------: | ------------------------------------------------------- | --------------------- |
-| projectId          | `string` |    ✅    | The ID of your project in Abby                          | -                     |
-| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version | -                     |
-| currentEnvironment | `string` |    ✅    | The current environment of your application             | [link](/environments) |
-| tests              | `object` |          | An object containing your defined A/B Tests             | -                     |
-| flags              | `object` |          | An object containing your defined Feature Flags         | -                     |
-| settings           | `object` |          | An object with additional settings for A/BBY            | -                     |
+| Name               | Type     | Required | Description                                              | details               |
+| ------------------ | -------- | :------: | -------------------------------------------------------  | --------------------- |
+| projectId          | `string` |    ✅    | The ID of your project in Abby                           | -                     |
+| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version  | -                     |
+| currentEnvironment | `string` |    ✅    | The current environment of your application              | [link](/environments) |
+| tests              | `object` |          | An object containing your defined A/B Tests              | -                     |
+| flags              | `array`  |          | An array containing your defined Feature Flag names      | -                     |
+| remoteConfig       | `object` |          | An object containing your Remote Configuration variables | -
+| settings           | `object` |          | An object with additional settings for A/BBY             | -                     |
 
 #### tests
 
@@ -123,25 +130,71 @@ The flags property is an array containing your defined Feature Flags. You probab
 ```ts
 const abby = createAbby({
   // ... your config
-  flags: { "test-flag": "Boolean" },
+  flags: ["test-flag"],
 });
+```
+
+#### remoteConfig 
+
+The remoteConfig property is an object containing your Remote Configuration variables and their respective types.
+
+##### Example
+```ts
+const abby = createAbby({
+  // ... your config
+  remoteConfig: {
+    myStringVariable: "String",
+    myNumberVariable: "Number",
+    myJSONVariable: "JSON",
+  },
+})
 ```
 
 #### settings
 
 The settings property is an object containing additional settings for A/BBY. The following properties are available:
 
-- `flags.defaultValues`: Allows you to set a general default value for each flag type. The keys of the object represent the types of the flags.
-  The default value is the following:
+- `flags.defaultValue`: Allows you to set a fallback boolean value for your Feature Flags, in case you forgot to add them 
+  in your dashboard or when they could not be fetched correctly.
 
   ```json
-  {
-    "Boolean": false,
-    "String": "",
-    "Number": 0,
-    "JSON": {}
-  }
+  flags: {
+    defaultValue: true,
+  },
   ```
 
 - `flags.devOverrides`: An object containing the values of feature flags in development mode. The keys of the object represent the names of the flags.
-  The values need to be of the type of the flag. This means if your flag is a `String` flag, this needs to be a `string`.
+
+  ```json
+  flags: {
+    devOverrides: {
+      showHeader: true,
+      showFooter: false,
+    },
+  },
+  ```
+
+- `remoteConfig.defaultValues`: An object containing default values for each Remote Configuration type.
+  
+  ```json
+  remoteConfig: {
+    defaultValues: {
+      String: "Default string value",
+      Number: 100,
+      JSON: { default: true },
+    },
+  },
+  ```
+
+- `remoteConfig.devOverrides`: An object containing the values of Remote Configuration variables in development mode. The keys of the object represent the names of the flags.
+  The values need to be of the type of the variable. The value must be of the same type as the variable.
+
+  ```json
+  remoteConfig: {
+    devOverrides: {
+      myStringVariable: "dev mode string value",
+      myNumberVariable: 100,
+      JSON: { devMode: true },
+    },
+  },
+  ```

--- a/apps/docs/pages/environments.mdx
+++ b/apps/docs/pages/environments.mdx
@@ -5,4 +5,6 @@ For example, you may have a `development` environment, a `staging` environment, 
 
 When using [Feature Flags](/feature-flags) it is often useful to have different values for the same flag in different environments.
 
+[Remote Configuration variables](/remote-config) can also be controlled per environment.
+
 When you create a new Environment all Flags will get a default value of `false` for that environment.

--- a/apps/docs/pages/feature-flags.mdx
+++ b/apps/docs/pages/feature-flags.mdx
@@ -3,9 +3,6 @@
 A feature flag in A/BBY is basically just a boolean that can be toggled via the Dashboard in A/BBY.
 This is useful for testing new features, or for hiding features that are not yet ready for production.
 
-A/BBY also allows you to create A/B Flags that are not just booleans. You can also create `Strings` and `Number` feature flags that allow you to inject
-different values for different environments remotely via the Dashboard.
-
 A feature flag is always toggled for a certain [Environment](/environments) which allows you to test features in different environments.
 For example, you can have a feature flag that is enabled in the `development` environment, but disabled in the `production` environment.
 

--- a/apps/docs/pages/index.mdx
+++ b/apps/docs/pages/index.mdx
@@ -2,7 +2,7 @@
 
 A/BBY is a Micro-SaaS that was created during the Dynaweek Hackathon.
 
-It aims to be the simpliest way to do A/B testing and Feature Flags on your website.
+It aims to be the simpliest way to do A/B testing, Feature Flags and Remote Configuration variables on your website.
 
 We tried to make A/BBY as simple as possible and create the **best** user experience. Therefore we decided to focus on `React` and `Next.js` for now.
 

--- a/apps/docs/pages/integrations/angular.mdx
+++ b/apps/docs/pages/integrations/angular.mdx
@@ -51,7 +51,10 @@ export default defineConfig({
     footer: { variants: ["dark", "orange", "green"] },
     // ... your tests
   },
-  flags: { darkMode: "Boolean", newFeature: "Boolean" },
+  flags: ['darkMode', 'newFeature'],
+  remoteConfig: {
+    customButtonText: "String",
+  }
 });
 ```
 
@@ -74,7 +77,7 @@ export class AppModule {}
 
 ### Using Abby in your Component
 
-You can now use Abby in your components. You will have access to the `AbbyService` which can be used to get one of your variants, a feature flag or act on any test.
+You can now use Abby in your components. You will have access to the `AbbyService` which can be used to get one of your variants, a feature flag, a remote config variable or act on any test.
 
 ```tsx
 import { AbbyService } from '@tryabby/angular';
@@ -107,9 +110,7 @@ You can also use Abby's directives to conditionally render elements based on the
 </ng-container>
 ```
 
-The `*abbyFlag`-Directive for now only interprets feature flags as a boolean. Support for checking string, number or object values will come later.
-You can however invert the boolean it returns by putting a `!` in front of the flag name like so:
-
+Feature Flags can be inverted by putting a `!` in front of the flagname.
 ```html
 <ng-container *abbyFlag="'!newFeature'">
   <!-- This will only be shown if the newFeature flag is falsy. -->
@@ -152,6 +153,8 @@ You can then consume the footer color in your template using the `async`-Pipe:
 
 ### Using Abby Pipes
 
+#### getAbbyVariant
+
 You can use the `getAbbyVariant` Pipe in your template to get the active variant of an AB Test.
 
 ```html
@@ -162,4 +165,12 @@ Optionally, you can pass in a lookup object, to map your variants to a custom ty
 
 ```html
 <p>{ "MyTestName" | getAbbyVariant: { A: 123, B: 456, C: 789 } | async }</p>
+```
+
+#### getRemoteConfig
+
+You can use the `getRemoteConfig` Pipe in your template to get the value for a Remote Configuration variable.
+
+```html
+<button>{{ "customButtonText" | getAbbyRemoteConfig | async }}</button>
 ```

--- a/apps/docs/pages/integrations/nextjs.mdx
+++ b/apps/docs/pages/integrations/nextjs.mdx
@@ -44,7 +44,10 @@ export default defineConfig({
     footer: { variants: ["dark", "orange", "green"] },
     // ... your tests
   },
-  flags: { darkMode: "Boolean", newFeature: "Boolean" },
+  flags: ["darkMode", "newFeature"],
+  remoteConfig: {
+    customButtonText: "String",
+  }
 });
 ```
 

--- a/apps/docs/pages/integrations/react.mdx
+++ b/apps/docs/pages/integrations/react.mdx
@@ -48,7 +48,10 @@ export default defineConfig({
     footer: { variants: ["dark", "orange", "green"] },
     // ... your tests
   },
-  flags: { darkMode: "Boolean", newFeature: "Boolean" },
+  flags: ["darkMode", "newFeature"],
+  remoteConfig: {
+    customButtonText: "String",
+  }
 });
 ```
 
@@ -61,7 +64,7 @@ Please copy the id of your project from the dashboard to get started.
 import { createAbby } from "@tryabby/react";
 import abbyConfig from "../abby.config";
 
-const { AbbyProvider, useAbby } = createAbby(abbyConfig);
+export const { AbbyProvider, useAbby, useFeatureFlag, useRemoteConfig } = createAbby(abbyConfig);
 ```
 
 ### Wrap your Application
@@ -149,3 +152,22 @@ function HomePage() {
   );
 }
 ```
+
+### useRemoteConfig
+
+The `useRemoteConfig` hook returns a value as specified in your `abby.config.ts`.
+The type of the returned value will automatically be inferred from your config.
+
+```tsx
+import { useRemoteConfig } from "./abby";
+
+function HomePage() {
+  const customButtonText = useRemoteConfig("customButtonText");
+
+  return (
+    <main className="p-6">
+      <h1>Welcome back, User</h1>
+      <button>{customButtonText}</button>
+    </main>
+  )
+}

--- a/apps/docs/pages/integrations/svelte.mdx
+++ b/apps/docs/pages/integrations/svelte.mdx
@@ -46,7 +46,10 @@ export default defineConfig({
     footer: { variants: ["dark", "orange", "green"] },
     // ... your tests
   },
-  flags: { darkMode: "Boolean", newFeature: "Boolean" },
+  flags: ["darkMode", "newFeature"],
+  remoteConfig: {
+    customButtonText: "String",
+  },
 });
 ```
 
@@ -148,5 +151,21 @@ The `useFeatureFlag` function returns a store providing a boolean value that ind
 	{#if $newFeature}
 		my super secret feature
 	{/if}
+</body>
+```
+
+## useRemoteConfig
+
+The `useRemoteConfig` function returns a store providing a custom value as specified in your `abby.config.ts`.
+The return type will automatically be inferred from your config.
+
+```svelte
+<script lang="ts">
+  import { abby } from "$lib/abby";
+  const customButtonText = abby.useRemoteConfig("customButtonText");
+</script>
+
+<body>
+  <button>{$customButtonText}</button>
 </body>
 ```

--- a/apps/docs/pages/nextjs.mdx
+++ b/apps/docs/pages/nextjs.mdx
@@ -2,7 +2,7 @@ import { Tab, Tabs } from "nextra-theme-docs";
 
 # Using A/BBY with Next.js
 
-A/BBY was built to be the best solution for Feature Flags and A/B Testing in Next.js.
+A/BBY was built to be the best solution for Feature Flags, A/B Testing and Remote Configuration variables in Next.js.
 It deeply integrates with Next.js and provides a seamless developer experience.
 
 ## Installation
@@ -52,9 +52,10 @@ export default defineConfig({
       variants: ["light", "dark"],
     },
   },
-  flags: {
-    useDarkMode: "Boolean",
-  },
+  flags: ["useDarkMode"],
+  remoteConfig: {
+    customButtonText: "String",
+  }
 });
 ```
 
@@ -67,7 +68,7 @@ This file will contain all the code (e.g. the A/BBY hooks) that is needed to int
 import { createAbby } from "@tryabby/next";
 import config from "../abby.config";
 
-export const { withAbby, AbbyProvider, useFeatureFlag, useAbby, withAbbyApiHandler, withAbbyEdge } = createAbby(config);
+export const { withAbby, AbbyProvider, useFeatureFlag, useAbby, withAbbyApiHandler, withAbbyEdge, useRemoteConfig } = createAbby(config);
 
 ```
 
@@ -117,6 +118,26 @@ export function HomePage() {
 ```
 
 You can now go to the A/BBY dashboard and enable the `useDarkmode` flag for your project. You will see the text "Darkmode is enabled" on your homepage.
+
+#### Remote Configuration
+
+```tsx
+// index.tsx
+
+import { useRemoteConfig } from "lib/abby";
+
+export function HomePage() {
+  const customButtonText = useRemoteConfig("customButtonText");
+
+  return (
+    <>
+      <h1>My Homepage</h1>
+      <button>{customButtonText}</button>
+    </>
+  )
+}
+```
+You can now control the text, which the button is displaying, on the A/BBY dashboard.
 
 #### A/B Tests
 

--- a/apps/docs/pages/reference/angular.mdx
+++ b/apps/docs/pages/reference/angular.mdx
@@ -9,14 +9,15 @@ You can then use the AbbyService in your components or services to interact with
 
 The `AbbyModule.forRoot()` method takes an object as a parameter. The object can contain the following properties:
 
-| Name               | Type     | Required | Description                                             | details               |
-| ------------------ | -------- | :------: | ------------------------------------------------------- | --------------------- |
-| projectId          | `string` |    ✅    | The ID of your project in Abby                          | -                     |
-| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version | -                     |
-| currentEnvironment | `string` |    ✅    | The current environment of your application             | [link](/environments) |
-| tests              | `object` |          | An object containing your defined A/B Tests             | -                     |
-| flags              | `object` |          | An array containing your defined Feature Flags          | -                     |
-| settings           | `object` |          | An object with additional settings for A/BBY            | -                     |
+| Name               | Type     | Required | Description                                                        | details               |
+| ------------------ | -------- | :------: | ------------------------------------------------------------------ | --------------------- |
+| projectId          | `string` |    ✅    | The ID of your project in Abby                                     | -                     |
+| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version            | -                     |
+| currentEnvironment | `string` |    ✅    | The current environment of your application                        | [link](/environments) |
+| tests              | `object` |          | An object containing your defined A/B Tests                        | -                     |
+| flags              | `array`  |          | An array containing your defined Feature Flags                     | -                     |
+| remoteConfig       | `object` |          | An object containing the name of your remote config and their type | -                     |
+| settings           | `object` |          | An object with additional settings for A/BBY                       | -                     |
 
 #### properties
 
@@ -44,8 +45,13 @@ export const abby = {
     test: {
       variants: ["control", "variant-a", "variant-b"],
     },
-    flags: { "test-flag": "Boolean" },
   },
+  flags: ["test-flag"],
+  remoteConfig: {
+    remoteConfig1: "String",
+    remoteConfig2: "Number",
+    remoteConfig3: "JSON",
+  }
 };
 
 @Injectable({
@@ -53,8 +59,9 @@ export const abby = {
   useExisting: AbbyService,
 })
 export class Abby extends AbbyService<
-  (typeof abby)["flags"][number],
-  keyof (typeof abby)["tests"]
+  InferFlagNames<typeof abby>,
+  InferTestNames<typeof abby>,
+  InferTests<typeof abby>,
 > {}
 ```
 
@@ -86,20 +93,30 @@ export class AppModule {}
 
 The settings property is an object containing additional settings for A/BBY. The following properties are available:
 
-- `flags.defaultValues`: Allows you to set a general default value for each flag type. The keys of the object represent the types of the flags.
-  The default value is the following:
+- `flags.defaultValue`: Allows you to set a general default boolean value for each Feature Flag type.
 
   ```json
-  {
-    "Boolean": false,
-    "String": "",
-    "Number": 0,
-    "JSON": {}
-  }
+  flags: {
+    defaultValue: false,
+  },
   ```
 
 - `flags.devOverrides`: An object containing the values of feature flags in development mode. The keys of the object represent the names of the flags.
-  The values need to be of the type of the flag. This means if your flag is a `String` flag, this needs to be a `string`.
+
+- `remoteConfig.defaultValue`: Allows you to set default values for the possible Remote Config types.
+
+  ```json
+  remoteConfig: {
+    defaultValues: {
+      String: "",
+      Number: 0,
+      JSON: {},
+    },
+  },
+  ```
+
+- `remoteConfig.devOverrides`: An object containing the values of Remote Configuration variables in development mode.
+  The keys of the object represent the names of the flags. The value must be assignable to the type of the variable.
 
 ## AbbyService
 
@@ -127,11 +144,23 @@ Resolves the value of a feature flag by the flagname.
 
 #### Parameters
 
-The name of the test or flag, needs to be one of the defined flags.
+The name of the flag, needs to be one of the defined flags.
 
 #### Return Value
 
 The value of the flag _Type: `boolean`_
+
+### getRemoteConfig
+
+`getRemoteConfig` is a function to access the value of a Remote Configuration variable. This can be called in a non-react scope (Regular Typescript, Edge Functions and API Routes)
+
+#### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+#### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 ### onAct
 
@@ -192,6 +221,19 @@ Automatically maps the active variant to a custom value if `lookupObject` is pro
 >
   Variants Pipe
 </h4>
+```
+
+### getAbbyRemoteConfig Pipe
+
+Returns the current value for a Remote Configuration variable.
+
+#### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your ABBY config.
+
+#### Example
+```html
+<p>angularRemoteConfig: {{ "angularRemoteConfig" | getAbbyRemoteConfig | async }}</p>
 ```
 
 ## Devtool Component

--- a/apps/docs/pages/reference/angular.mdx
+++ b/apps/docs/pages/reference/angular.mdx
@@ -62,6 +62,8 @@ export class Abby extends AbbyService<
   InferFlagNames<typeof abby>,
   InferTestNames<typeof abby>,
   InferTests<typeof abby>,
+  InferRemoteConfig<typeof abby>,
+  InferRemoteConfigName<typeof abby>
 > {}
 ```
 

--- a/apps/docs/pages/reference/http.mdx
+++ b/apps/docs/pages/reference/http.mdx
@@ -30,7 +30,13 @@ Returns the data for the given project.
   "flags": [
     {
       "name": "Flag 1",
-      "isEnabled": true
+      "value": true
+    }
+  ],
+  "remoteConfig": [
+    {
+      "name": "Remote Config 1",
+      "value": "Foobar"
     }
   ]
 }

--- a/apps/docs/pages/reference/nextjs.mdx
+++ b/apps/docs/pages/reference/nextjs.mdx
@@ -6,14 +6,15 @@
 
 The `createAbby` function takes an object as a parameter. The object can contain the following properties:
 
-| Name               | Type     | Required | Description                                             | details               |
-| ------------------ | -------- | :------: | ------------------------------------------------------- | --------------------- |
-| projectId          | `string` |    ✅    | The ID of your project in Abby                          | -                     |
-| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version | -                     |
-| currentEnvironment | `string` |    ✅    | The current environment of your application             | [link](/environments) |
-| tests              | `object` |          | An object containing your defined A/B Tests             | -                     |
-| flags              | `object` |          | An array containing your defined Feature Flags          | -                     |
-| settings           | `object` |          | An object with additional settings for A/BBY            | -                     |
+| Name               | Type     | Required | Description                                                        | details               |
+| ------------------ | -------- | :------: | ------------------------------------------------------------------ | --------------------- |
+| projectId          | `string` |    ✅    | The ID of your project in Abby                                     | -                     |
+| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version            | -                     |
+| currentEnvironment | `string` |    ✅    | The current environment of your application                        | [link](/environments) |
+| tests              | `object` |          | An object containing your defined A/B Tests                        | -                     |
+| flags              | `array`  |          | An array containing your defined Feature Flags                     | -                     |
+| remoteConfig       | `object` |          | An object containing the name of your remote config and their type | -                     |
+| settings           | `object` |          | An object with additional settings for A/BBY                       | -                     |
 
 #### tests
 
@@ -46,7 +47,7 @@ The flags property is an array containing your defined Feature Flags. You probab
 ```ts
 const abby = createAbby({
   // ... your config
-  flags: { "test-flag": "Boolean" },
+  flags: ['test-flag'],
 });
 ```
 
@@ -54,20 +55,30 @@ const abby = createAbby({
 
 The settings property is an object containing additional settings for A/BBY. The following properties are available:
 
-- `flags.defaultValues`: Allows you to set a general default value for each flag type. The keys of the object represent the types of the flags.
-  The default value is the following:
+- `flags.defaultValue`: Allows you to set a general default boolean value for each Feature Flag type.
 
   ```json
-  {
-    "Boolean": false,
-    "String": "",
-    "Number": 0,
-    "JSON": {}
-  }
+  flags: {
+    defaultValue: false,
+  },
   ```
 
 - `flags.devOverrides`: An object containing the values of feature flags in development mode. The keys of the object represent the names of the flags.
-  The values need to be of the type of the flag. This means if your flag is a `String` flag, this needs to be a `string`.
+
+- `remoteConfig.defaultValue`: Allows you to set default values for the possible Remote Config types.
+
+  ```json
+  remoteConfig: {
+    defaultValues: {
+      String: "",
+      Number: 0,
+      JSON: {},
+    },
+  },
+  ```
+
+- `remoteConfig.devOverrides`: An object containing the values of Remote Configuration variables in development mode.
+  The keys of the object represent the names of the flags. The value must be assignable to the type of the variable.
 
 ### Return Values
 
@@ -94,11 +105,23 @@ New users will get a random value for a test depending on the defined weights
 
 ##### Parameters
 
-The name of the test or flag, needs to be one of the defined flags.
+The name of the flag, needs to be one of the defined flags.
 
 ##### Return Value
 
 The value of the flag _Type: `boolean`_
+
+#### useRemoteConfig
+
+`useRemotConfig` is a React hook that is used to access the value of a Remote Configuration variable.
+
+##### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+##### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 #### AbbyProvider
 
@@ -116,6 +139,22 @@ A react component to wrap your application.
 ##### Parameters
 
 The name of the test or flag, needs to be one of the defined flags.
+
+##### Return Value
+
+The value of the flag _Type: `boolean`_
+
+#### getRemoteConfig
+
+`getRemoteConfig` is a function to access the value of a Remote Configuration variable. This can be called in a non-react scope (Regular Typescript, Edge Functions and API Routes)
+
+##### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+##### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 #### getABTestValue
 
@@ -240,11 +279,11 @@ export default withAbbyApiHandler((req, res) => {
 This is a function which returns a function that can be used to reset the stored variant for the current user.
 This means the cookie will be deleted and the user will get a new variant on the next page load.
 
-#### Parameters
+##### Parameters
 
 The name of the test, needs to be one of the defined tests.
 
-#### Example
+##### Example
 
 ```tsx
 import { getABResetFunction } from "lib/abby";

--- a/apps/docs/pages/reference/react.mdx
+++ b/apps/docs/pages/reference/react.mdx
@@ -6,14 +6,15 @@
 
 The `createAbby` function takes an object as a parameter. The object can contain the following properties:
 
-| Name               | Type     | Required | Description                                             | details               |
-| ------------------ | -------- | :------: | ------------------------------------------------------- | --------------------- |
-| projectId          | `string` |    ✅    | The ID of your project in Abby                          | -                     |
-| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version | -                     |
-| currentEnvironment | `string` |    ✅    | The current environment of your application             | [link](/environments) |
-| tests              | `object` |          | An object containing your defined A/B Tests             | -                     |
-| flags              | `object` |          | An array containing your defined Feature Flags          | -                     |
-| settings           | `object` |          | An object with additional settings for A/BBY            | -                     |
+| Name               | Type     | Required | Description                                                        | details               |
+| ------------------ | -------- | :------: | ------------------------------------------------------------------ | --------------------- |
+| projectId          | `string` |    ✅    | The ID of your project in Abby                                     | -                     |
+| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version            | -                     |
+| currentEnvironment | `string` |    ✅    | The current environment of your application                        | [link](/environments) |
+| tests              | `object` |          | An object containing your defined A/B Tests                        | -                     |
+| flags              | `array`  |          | An array containing your defined Feature Flags                     | -                     |
+| remoteConfig       | `object` |          | An object containing the name of your remote config and their type | -                     |
+| settings           | `object` |          | An object with additional settings for A/BBY                       | -                     |
 
 #### tests
 
@@ -46,7 +47,7 @@ The flags property is an array containing your defined Feature Flags. You probab
 ```ts
 const abby = createAbby({
   // ... your config
-  flags: { "test-flag": "Boolean" },
+  flags: ['test-flag'],
 });
 ```
 
@@ -54,20 +55,30 @@ const abby = createAbby({
 
 The settings property is an object containing additional settings for A/BBY. The following properties are available:
 
-- `flags.defaultValues`: Allows you to set a general default value for each flag type. The keys of the object represent the types of the flags.
-  The default value is the following:
+- `flags.defaultValue`: Allows you to set a general default boolean value for each Feature Flag type.
 
   ```json
-  {
-    "Boolean": false,
-    "String": "",
-    "Number": 0,
-    "JSON": {}
-  }
+  flags: {
+    defaultValue: false,
+  },
   ```
 
 - `flags.devOverrides`: An object containing the values of feature flags in development mode. The keys of the object represent the names of the flags.
-  The values need to be of the type of the flag. This means if your flag is a `String` flag, this needs to be a `string`.
+
+- `remoteConfig.defaultValue`: Allows you to set default values for the possible Remote Config types.
+
+  ```json
+  remoteConfig: {
+    defaultValues: {
+      String: "",
+      Number: 0,
+      JSON: {},
+    },
+  },
+  ```
+
+- `remoteConfig.devOverrides`: An object containing the values of Remote Configuration variables in development mode.
+  The keys of the object represent the names of the flags. The value must be assignable to the type of the variable.
 
 ### Return Values
 
@@ -94,11 +105,23 @@ New users will get a random value for a test depending on the defined weights
 
 ##### Parameters
 
-The name of the test or flag, needs to be one of the defined flags.
+The name of the flag, needs to be one of the defined flags.
 
 ##### Return Value
 
 The value of the flag _Type: `boolean`_
+
+#### useRemoteConfig
+
+`useRemotConfig` is a React hook that is used to access the value of a Remote Configuration variable.
+
+##### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+##### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 #### AbbyProvider
 
@@ -116,6 +139,22 @@ A react component to wrap your application.
 ##### Parameters
 
 The name of the test or flag, needs to be one of the defined flags.
+
+##### Return Value
+
+The value of the flag _Type: `boolean`_
+
+#### getRemoteConfig
+
+`getRemoteConfig` is a function to access the value of a Remote Configuration variable. This can be called in a non-react scope.
+
+##### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+##### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 #### getABTestValue
 
@@ -152,11 +191,11 @@ export const AbbyDevtools = withDevtools(AbbyDevTools);
 This is a function which returns a function that can be used to reset the stored variant for the current user.
 This means the cookie will be deleted and the user will get a new variant on the next page load.
 
-#### Parameters
+##### Parameters
 
 The name of the test, needs to be one of the defined tests.
 
-#### Example
+##### Example
 
 ```tsx
 import { getABResetFunction } from "lib/abby";

--- a/apps/docs/pages/reference/svelte.mdx
+++ b/apps/docs/pages/reference/svelte.mdx
@@ -6,14 +6,15 @@
 
 The `createAbby` function takes an object as a parameter. The object can contain the following properties:
 
-| Name               | Type     | Required | Description                                             | details               |
-| ------------------ | -------- | :------: | ------------------------------------------------------- | --------------------- |
-| projectId          | `string` |    ✅    | The ID of your project in Abby                          | -                     |
-| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version | -                     |
-| currentEnvironment | `string` |    ✅    | The current environment of your application             | [link](/environments) |
-| tests              | `object` |          | An object containing your defined A/B Tests             | -                     |
-| flags              | `object` |          | An array containing your defined Feature Flags          | -                     |
-| settings           | `object` |          | An object with additional settings for A/BBY            | -                     |
+| Name               | Type     | Required | Description                                                        | details               |
+| ------------------ | -------- | :------: | ------------------------------------------------------------------ | --------------------- |
+| projectId          | `string` |    ✅    | The ID of your project in Abby                                     | -                     |
+| apiUrl             | `string` |          | The URL of the Abby API. Defaults to the hosted version            | -                     |
+| currentEnvironment | `string` |    ✅    | The current environment of your application                        | [link](/environments) |
+| tests              | `object` |          | An object containing your defined A/B Tests                        | -                     |
+| flags              | `array`  |          | An array containing your defined Feature Flags                     | -                     |
+| remoteConfig       | `object` |          | An object containing the name of your remote config and their type | -                     |
+| settings           | `object` |          | An object with additional settings for A/BBY                       | -                     |
 
 #### tests
 
@@ -46,7 +47,7 @@ The flags property is an array containing your defined Feature Flags. You probab
 ```ts
 const abby = createAbby({
   // ... your config
-  flags: { "test-flag": "Boolean" },
+  flags: ["test-flag"],
 });
 ```
 
@@ -54,20 +55,30 @@ const abby = createAbby({
 
 The settings property is an object containing additional settings for A/BBY. The following properties are available:
 
-- `flags.defaultValues`: Allows you to set a general default value for each flag type. The keys of the object represent the types of the flags.
-  The default value is the following:
+- `flags.defaultValue`: Allows you to set a general default boolean value for each Feature Flag type.
 
   ```json
-  {
-    "Boolean": false,
-    "String": "",
-    "Number": 0,
-    "JSON": {}
-  }
+  flags: {
+    defaultValue: false,
+  },
   ```
 
 - `flags.devOverrides`: An object containing the values of feature flags in development mode. The keys of the object represent the names of the flags.
-  The values need to be of the type of the flag. This means if your flag is a `String` flag, this needs to be a `string`.
+
+- `remoteConfig.defaultValue`: Allows you to set default values for the possible Remote Config types.
+
+  ```json
+  remoteConfig: {
+    defaultValues: {
+      String: "",
+      Number: 0,
+      JSON: {},
+    },
+  },
+  ```
+
+- `remoteConfig.devOverrides`: An object containing the values of Remote Configuration variables in development mode.
+  The keys of the object represent the names of the flags. The value must be assignable to the type of the variable.
 
 ### Return Values
 
@@ -90,15 +101,27 @@ New users will get a random value for a test depending on the defined weights
 
 #### useFeatureFlag
 
-`useFeatureFlag` is a function providing acces to a store that is used to access the value of a Feature Flag.
+`useFeatureFlag` is a function providing access to a store that is used to access the value of a Feature Flag.
 
 ##### Parameters
 
-The name of the test or flag, needs to be one of the defined flags.
+The name of the flag, needs to be one of the defined flags.
 
 ##### Return Value
 
 A store providing the value of the flag _Type: `boolean`_
+
+#### useRemoteConfig
+
+`useRemoteConfig` is a function providing access to a store that is used to access the value of a Remote Configuration variable.
+
+##### Parameters
+
+The name of the Remote Configuration variable. This needs to be one of the defined keys in your `abby.config.ts`.
+
+##### Return Value
+
+A store providing the value of the Remote Configuration variable. The type will be looked up from your `abby.config.ts`.
 
 #### AbbyProvider
 
@@ -116,6 +139,22 @@ A svelte component to wrap your application.
 ##### Parameters
 
 The name of the test or flag, needs to be one of the defined flags.
+
+##### Return Value
+
+The value of the flag _Type: `boolean`_
+
+#### getRemoteConfig
+
+`getRemoteConfig` is a function to access the value of a Remote Configuration variable. This can be called in a non-svelte scope (Regular Typescript, Edge Functions and API Routes)
+
+##### Parameters
+
+The name of the Remote Configuration variable, which needs to be one of the keys in your `remoteConfig` object in your `abby.config.ts`.
+
+##### Return Value
+
+The current value of the Remote Configuration variable. The type will be according to the specified type in the `abby.config.ts`
 
 #### getABTestValue
 
@@ -171,6 +210,6 @@ export const load = abby.withAbby();
 This is a function which returns a function that can be used to reset the stored variant for the current user.
 This means the cookie will be deleted and the user will get a new variant on the next page load.
 
-#### Parameters
+##### Parameters
 
 The name of the test, needs to be one of the defined tests.

--- a/apps/docs/pages/remote-config.mdx
+++ b/apps/docs/pages/remote-config.mdx
@@ -1,0 +1,8 @@
+# Remote Configuration variables
+Remote Configuration variables are custom String, Number and JSON values, which you can control per [Environment](environments)
+
+They behave similarly to Feature Flags, but allow you to control more types of values than just booleans.
+You could for example display a dynamic string on your page, which you can easily change on the A/BBY Dashboard for all users.
+
+The [A/BBY Devtools](devtools) also allow you to control Remote Configuration variables in realtime during development,
+providing a nice developer experience.

--- a/apps/web/CHANGELOG.md
+++ b/apps/web/CHANGELOG.md
@@ -1,5 +1,14 @@
 # web
 
+## 0.2.28
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/devtools@5.0.0
+  - @tryabby/core@5.0.0
+  - @tryabby/next@5.0.0
+
 ## 0.2.27
 
 ### Patch Changes

--- a/apps/web/abby.config.ts
+++ b/apps/web/abby.config.ts
@@ -11,10 +11,8 @@ export default defineConfig({
       variants: ["A", "B"],
     },
   },
-  flags: {
-    AdvancedTestStats: "Boolean",
-    showFooter: "Boolean",
-    test: "Boolean",
+  flags: ["AdvancedTestStats", "showFooter", "test"],
+  remoteConfig: {
     abc: "JSON",
   },
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "web",
-  "version": "0.2.27",
+  "version": "0.2.28",
   "private": true,
   "scripts": {
     "build": "next build",

--- a/apps/web/src/components/AddFeatureFlagModal.tsx
+++ b/apps/web/src/components/AddFeatureFlagModal.tsx
@@ -19,6 +19,7 @@ type Props = {
   onClose: () => void;
   isOpen: boolean;
   projectId: string;
+  isRemoteConfig?: boolean;
 };
 
 export type FlagFormValues = {
@@ -32,11 +33,13 @@ export function ChangeFlagForm({
   onChange: onChangeHandler,
   errors,
   canChangeType = true,
+  isRemoteConfig,
 }: {
   initialValues: FlagFormValues;
   onChange: (values: FlagFormValues) => void;
   errors: Partial<FlagFormValues>;
   canChangeType?: boolean;
+  isRemoteConfig?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const inputClassName =
@@ -55,7 +58,7 @@ export function ChangeFlagForm({
     const newState = { ...state, ...values };
 
     // if type changed, save the value
-    if (values.type !== null && values.type !== state.type) {
+    if (values.type != null && values.type !== state.type) {
       valueRef.current[state.type] = state.value;
       newState.value = valueRef.current[newState.type] ?? "";
     }
@@ -73,42 +76,49 @@ export function ChangeFlagForm({
           type="text"
           defaultValue={initialValues.name}
           onChange={(e) => onChange({ name: e.target.value })}
-          placeholder="My new feature flag"
+          placeholder={isRemoteConfig ? "My Remote Config" : "My Feature Flag"}
           className={inputClassName}
         />
         {errors.name && (
           <p className="mt-1 text-sm text-red-500">{errors.name}</p>
         )}
       </div>
-      <div>
-        <label className="mb-1 block text-pink-50">Type</label>
-        <RadioSelect
-          isDisabled={!canChangeType}
-          options={Object.entries(FeatureFlagType).map(([key, flagType]) => ({
-            label: (
-              <div
-                className={cn(
-                  "flex items-center",
-                  getFlagTypeClassName(flagType)
-                )}
-              >
-                <FlagIcon type={flagType} className="mr-2 inline-block" />
-                <span>{transformDBFlagTypeToclient(flagType)}</span>
-              </div>
-            ),
-            value: flagType,
-          }))}
-          onChange={(value) => {
-            if (!canChangeType) return;
+      {isRemoteConfig && (
+        <div>
+          <label className="mb-1 block text-pink-50">Type</label>
+          <RadioSelect
+            isDisabled={!canChangeType}
+            options={Object.entries(FeatureFlagType)
+              // we omit boolean for remote config
+              .filter(
+                ([, flagType]) => isRemoteConfig && flagType !== "BOOLEAN"
+              )
+              .map(([key, flagType]) => ({
+                label: (
+                  <div
+                    className={cn(
+                      "flex items-center",
+                      getFlagTypeClassName(flagType)
+                    )}
+                  >
+                    <FlagIcon type={flagType} className="mr-2 inline-block" />
+                    <span>{transformDBFlagTypeToclient(flagType)}</span>
+                  </div>
+                ),
+                value: flagType,
+              }))}
+            onChange={(value) => {
+              if (!canChangeType) return;
 
-            onChange({
-              type: value,
-              value: value === "BOOLEAN" ? "false" : "",
-            });
-          }}
-          initialValue={initialValues.type}
-        />
-      </div>
+              onChange({
+                type: value,
+                value: value === "BOOLEAN" ? "false" : "",
+              });
+            }}
+            initialValue={initialValues.type}
+          />
+        </div>
+      )}
       <div>
         <label className="mb-1 block text-pink-50">Value</label>
         {state.type === "BOOLEAN" && (
@@ -123,7 +133,9 @@ export function ChangeFlagForm({
             type="text"
             value={state.value}
             onChange={(e) => onChange({ value: e.target.value })}
-            placeholder="My Flag Value"
+            placeholder={
+              isRemoteConfig ? "My Remote Config" : "My Feature Flag"
+            }
             className="form-input w-full rounded-md border border-gray-500 bg-gray-600 px-4 py-2 text-white placeholder-gray-400 shadow-sm focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
           />
         )}
@@ -154,7 +166,12 @@ export function ChangeFlagForm({
   );
 }
 
-export const AddFeatureFlagModal = ({ onClose, isOpen, projectId }: Props) => {
+export const AddFeatureFlagModal = ({
+  onClose,
+  isOpen,
+  projectId,
+  isRemoteConfig,
+}: Props) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const ctx = trpc.useContext();
   const stateRef = useRef<FlagFormValues>();
@@ -218,11 +235,12 @@ export const AddFeatureFlagModal = ({ onClose, isOpen, projectId }: Props) => {
         errors={errors}
         initialValues={{
           name: "",
-          type: "BOOLEAN",
-          value: "false",
+          type: isRemoteConfig ? "STRING" : "BOOLEAN",
+          value: isRemoteConfig ? "" : "false",
         }}
         onChange={(newState) => (stateRef.current = newState)}
         canChangeType
+        isRemoteConfig={isRemoteConfig}
       />
     </Modal>
   );

--- a/apps/web/src/components/AddFeatureFlagModal.tsx
+++ b/apps/web/src/components/AddFeatureFlagModal.tsx
@@ -189,7 +189,9 @@ export const AddFeatureFlagModal = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
-      title="Create new feature flag"
+      title={
+        isRemoteConfig ? "Create new remote config" : "Create new feature flag"
+      }
       confirmText="Create"
       initialFocusRef={inputRef}
       size="full"

--- a/apps/web/src/components/FlagPage.tsx
+++ b/apps/web/src/components/FlagPage.tsx
@@ -218,6 +218,7 @@ export const FeatureFlagPageContent = ({
             isOpen={isCreateFlagModalOpen}
             onClose={() => setIsCreateFlagModalOpen(false)}
             projectId={projectId}
+            isRemoteConfig={type === "Remote Config"}
           />
           <CreateEnvironmentModal
             isOpen={isCreateEnvironmentModalOpen}

--- a/apps/web/src/components/FlagPage.tsx
+++ b/apps/web/src/components/FlagPage.tsx
@@ -1,0 +1,362 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "components/Tooltip";
+import { AddFeatureFlagModal } from "components/AddFeatureFlagModal";
+import { CreateEnvironmentModal } from "components/CreateEnvironmentModal";
+import { DashboardHeader } from "components/DashboardHeader";
+import { Editor } from "components/Editor";
+import { FeatureFlag } from "components/FeatureFlag";
+import { Layout } from "components/Layout";
+import { FullPageLoadingSpinner } from "components/LoadingSpinner";
+import { Modal } from "components/Modal";
+import { useProjectId } from "lib/hooks/useProjectId";
+import { NextPageWithLayout } from "pages/_app";
+import { useState } from "react";
+import { toast } from "react-hot-toast";
+import { AiOutlinePlus } from "react-icons/ai";
+import { BiInfoCircle } from "react-icons/bi";
+import { trpc } from "utils/trpc";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "components/DropdownMenu";
+import { BsThreeDotsVertical } from "react-icons/bs";
+import { EditIcon, FileEditIcon, TrashIcon } from "lucide-react";
+import { Input } from "components/Input";
+import { InferQueryResult } from "@trpc/react-query/dist/utils/inferReactQueryProcedure";
+import { appRouter } from "server/trpc/router/_app";
+import { FeatureFlagType } from "@prisma/client";
+
+const EditTitleModal = ({
+  flagId,
+  isOpen,
+  onClose,
+  title,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  flagId: string;
+}) => {
+  const [newTitle, setNewTitle] = useState(title);
+  const trpcContext = trpc.useContext();
+  const { mutate: updateTitle } = trpc.flags.updateFlagTitle.useMutation({
+    onSuccess() {
+      toast.success("Successfully updated the title");
+      trpcContext.flags.getFlags.invalidate();
+      onClose();
+    },
+    onError() {
+      toast.error("Failed to update the title");
+    },
+  });
+  return (
+    <Modal
+      title="Update Title"
+      confirmText="Save"
+      onConfirm={() => updateTitle({ flagId, title: newTitle })}
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <Input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} />
+    </Modal>
+  );
+};
+
+const EditDescriptionModal = ({
+  isOpen,
+  onClose,
+  flagId,
+  description,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  flagId: string;
+  description: string;
+}) => {
+  const [newDescription, setNewDescription] = useState(description);
+  const trpcContext = trpc.useContext();
+  const { mutate: updateDescription } =
+    trpc.flags.updateDescription.useMutation({
+      onSuccess() {
+        toast.success("Successfully updated description");
+        trpcContext.flags.getFlags.invalidate();
+        onClose();
+      },
+      onError() {
+        toast.error("Failed to update description");
+      },
+    });
+
+  return (
+    <Modal
+      title="Update Description"
+      confirmText="Save"
+      onConfirm={() =>
+        updateDescription({ flagId, description: newDescription })
+      }
+      size="full"
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <Editor
+        className="w-full"
+        content={newDescription}
+        onUpdate={setNewDescription}
+      />
+      <small className="text-pink-50/80">
+        <i>__Markdown__</i> is <b>**supported**</b>
+      </small>
+    </Modal>
+  );
+};
+
+const DeleteFlagModal = ({
+  isOpen,
+  onClose,
+  projectId,
+  flagName,
+  type,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+  projectId: string;
+  flagName: string;
+  type: FeatureFlagType;
+}) => {
+  const trpcContext = trpc.useContext();
+  const { mutate: deleteFlag } = trpc.flags.removeFlag.useMutation({
+    onSuccess() {
+      toast.success(`Deleted ${type === "BOOLEAN" ? "flag" : "config"}`);
+      trpcContext.flags.getFlags.invalidate();
+      onClose();
+    },
+    onError() {
+      toast.error(`Failed to delete ${type === "BOOLEAN" ? "flag" : "config"}`);
+    },
+  });
+
+  return (
+    <Modal
+      title="Delete Flag"
+      confirmText="Delete"
+      onConfirm={() => deleteFlag({ name: flagName, projectId })}
+      isOpen={isOpen}
+      onClose={onClose}
+    >
+      <p>
+        Are you sure that you want to delete the Flag <b>{flagName}</b>?
+      </p>
+    </Modal>
+  );
+};
+
+export const FeatureFlagPageContent = ({
+  data,
+  type,
+}: {
+  data: NonNullable<
+    InferQueryResult<(typeof appRouter)["flags"]["getFlags"]>["data"]
+  >;
+  type: "Flags" | "Remote Config";
+}) => {
+  const [isCreateFlagModalOpen, setIsCreateFlagModalOpen] = useState(false);
+  const [activeFlagInfo, setActiveFlagInfo] = useState<{
+    id: string;
+    action: "editDescription" | "editName" | "delete";
+  } | null>(null);
+
+  const [isCreateEnvironmentModalOpen, setIsCreateEnvironmentModalOpen] =
+    useState(false);
+
+  const projectId = useProjectId();
+
+  const activeFlag = data.flags.find((flag) => flag.id === activeFlagInfo?.id);
+
+  if (data.environments.length === 0)
+    return (
+      <div className="mt-48 flex flex-col items-center justify-center">
+        <h1 className="text-2xl font-semibold">
+          You don&apos;t have any environments set up!
+        </h1>
+        <h2>
+          You need to have at least one environment to set up{" "}
+          {type === "Flags" ? "feature flags" : "remote config"}
+        </h2>
+        <button
+          className="mt-4 rounded-md bg-pink-600 px-4 py-2 font-semibold text-white transition-colors duration-200 hover:bg-pink-700"
+          onClick={() => setIsCreateEnvironmentModalOpen(true)}
+        >
+          Create Environment
+        </button>
+        <CreateEnvironmentModal
+          isOpen={isCreateEnvironmentModalOpen}
+          onClose={() => setIsCreateEnvironmentModalOpen(false)}
+          projectId={projectId}
+        />
+      </div>
+    );
+
+  return (
+    <>
+      <div>
+        <div className="flex justify-end space-x-2">
+          <button
+            className="mb-4 flex items-center space-x-2 rounded-md bg-gray-600 px-4 py-2 text-white"
+            onClick={() => setIsCreateEnvironmentModalOpen(true)}
+          >
+            <AiOutlinePlus /> <span>Add Env</span>
+          </button>
+          <button
+            className="mb-4 flex items-center space-x-2 rounded-md bg-pink-600 px-4 py-2 text-white"
+            onClick={() => setIsCreateFlagModalOpen(true)}
+          >
+            <AiOutlinePlus />{" "}
+            <span>Add {type === "Flags" ? "Flag" : "Config"}</span>
+          </button>
+          <AddFeatureFlagModal
+            isOpen={isCreateFlagModalOpen}
+            onClose={() => setIsCreateFlagModalOpen(false)}
+            projectId={projectId}
+          />
+          <CreateEnvironmentModal
+            isOpen={isCreateEnvironmentModalOpen}
+            onClose={() => setIsCreateEnvironmentModalOpen(false)}
+            projectId={projectId}
+          />
+        </div>
+
+        <div className="space-y-3">
+          {data.flags.map((currentFlag) => {
+            return (
+              <section
+                key={currentFlag.id}
+                className="w-full rounded-md bg-gray-600/50 p-4"
+              >
+                <div className="flex justify-between">
+                  <div className="flex items-center space-x-3">
+                    <h2 className="font-bold text-pink-200">
+                      {currentFlag.name}
+                    </h2>
+
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button>
+                          <BiInfoCircle />
+                        </button>
+                      </TooltipTrigger>
+
+                      <TooltipContent
+                        side="bottom"
+                        align="start"
+                        alignOffset={-35}
+                        className="w-[250px]"
+                      >
+                        <h1 className="mb-4 font-semibold">Description:</h1>
+                        <p
+                          className="prose prose-invert text-pink-50"
+                          dangerouslySetInnerHTML={{
+                            __html:
+                              currentFlag.description ??
+                              "<p>No description</p>",
+                          }}
+                        />
+                      </TooltipContent>
+                    </Tooltip>
+                  </div>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <button className="inline-flex h-[35px] w-[35px] items-center justify-center rounded-md bg-transparent text-pink-50 outline-none hover:bg-gray-800 focus:bg-gray-800 ">
+                        <BsThreeDotsVertical />
+                      </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onClick={() => {
+                          setActiveFlagInfo({
+                            id: currentFlag.id,
+                            action: "editName",
+                          });
+                        }}
+                      >
+                        <EditIcon className="mr-4 h-4 w-4" />
+                        Edit Name
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="cursor-pointer"
+                        onClick={() => {
+                          setActiveFlagInfo({
+                            id: currentFlag.id,
+                            action: "editDescription",
+                          });
+                        }}
+                      >
+                        <FileEditIcon className="mr-4 h-4 w-4" />
+                        Edit Description
+                      </DropdownMenuItem>
+                      <DropdownMenuItem
+                        className="cursor-pointer focus:!bg-red-700 focus:!text-white"
+                        onClick={() => {
+                          setActiveFlagInfo({
+                            id: currentFlag.id,
+                            action: "delete",
+                          });
+                        }}
+                      >
+                        <TrashIcon className="mr-4 h-4 w-4" />
+                        Delete {type === "Flags" ? "Flag" : "Config"}
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
+                </div>
+                <div className="relative mt-3 grid grid-cols-[repeat(auto-fill,minmax(205px,1fr))] gap-x-8 gap-y-4 pr-2">
+                  {currentFlag.values
+                    .sort(
+                      (a, b) =>
+                        a.environment.sortIndex - b.environment.sortIndex
+                    )
+                    .map((flagValue) => (
+                      <FeatureFlag
+                        key={flagValue.flagId + flagValue.environment.id}
+                        flag={currentFlag}
+                        projectId={projectId}
+                        environmentName={flagValue.environment.name}
+                        flagValueId={flagValue.id}
+                        type={currentFlag.type}
+                      />
+                    ))}
+                </div>
+              </section>
+            );
+          })}
+        </div>
+      </div>
+      {activeFlag && (
+        <>
+          <EditTitleModal
+            key={activeFlag.id}
+            flagId={activeFlag.id}
+            title={activeFlag.name ?? ""}
+            isOpen={activeFlagInfo?.action === "editName"}
+            onClose={() => setActiveFlagInfo(null)}
+          />
+          <EditDescriptionModal
+            key={activeFlag.id}
+            flagId={activeFlag.id}
+            description={activeFlag.description ?? ""}
+            isOpen={activeFlagInfo?.action === "editDescription"}
+            onClose={() => setActiveFlagInfo(null)}
+          />
+          <DeleteFlagModal
+            flagName={activeFlag.name}
+            projectId={projectId}
+            isOpen={activeFlagInfo?.action === "delete"}
+            onClose={() => setActiveFlagInfo(null)}
+            type={activeFlag.type}
+          />
+        </>
+      )}
+    </>
+  );
+};

--- a/apps/web/src/components/Layout.tsx
+++ b/apps/web/src/components/Layout.tsx
@@ -22,7 +22,7 @@ import { UserInfo } from "./UserInfo";
 import { CreateProjectModal } from "./CreateProjectModal";
 import { useSession } from "next-auth/react";
 import { twMerge } from "tailwind-merge";
-import { Book, ExternalLink } from "lucide-react";
+import { Book, ExternalLink, SlidersHorizontal } from "lucide-react";
 import { DOCS_URL } from "@tryabby/core";
 
 const navItemClass = (isActive: boolean) =>
@@ -110,16 +110,6 @@ const SideBar =
             </div>
             <hr className="mb-2 border-pink-50/20" />
             <Link
-              href={`/projects/${currentProjectId}`}
-              onClick={closeSidebar}
-              className={navItemClass(
-                router.pathname.endsWith("/projects/[projectId]")
-              )}
-            >
-              <MdSpaceDashboard className="mr-2" />
-              A/B Tests
-            </Link>
-            <Link
               href={`/projects/${currentProjectId}/flags`}
               onClick={closeSidebar}
               className={navItemClass(
@@ -130,6 +120,16 @@ const SideBar =
               Feature Flags
             </Link>
             <Link
+              href={`/projects/${currentProjectId}/remote-config`}
+              onClick={closeSidebar}
+              className={navItemClass(
+                router.pathname.endsWith("/projects/[projectId]/remote-config")
+              )}
+            >
+              <SlidersHorizontal className="mr-2 w-5" />
+              Remote Config
+            </Link>
+            <Link
               href={`/projects/${currentProjectId}/environments`}
               onClick={closeSidebar}
               className={navItemClass(
@@ -138,6 +138,16 @@ const SideBar =
             >
               <FiServer className="mr-2" />
               Environments
+            </Link>
+            <Link
+              href={`/projects/${currentProjectId}`}
+              onClick={closeSidebar}
+              className={navItemClass(
+                router.pathname.endsWith("/projects/[projectId]")
+              )}
+            >
+              <MdSpaceDashboard className="mr-2" />
+              A/B Tests
             </Link>
             <Link
               href={`/projects/${currentProjectId}/settings`}

--- a/apps/web/src/lib/flags.ts
+++ b/apps/web/src/lib/flags.ts
@@ -1,7 +1,14 @@
 import { FeatureFlag, FeatureFlagType } from "@prisma/client";
-import { assertUnreachable } from "@tryabby/core";
-import { FlagValueString } from "@tryabby/core";
+import {
+  assertUnreachable,
+  DEFAULT_FEATURE_FLAG_VALUE,
+  getDefaultRemoteConfigValue,
+  RemoteConfigValue,
+  RemoteConfigValueString,
+  stringifyRemoteConfigValue,
+} from "@tryabby/core";
 import { groupBy } from "lodash-es";
+import { FlagValueString } from "../types/flags";
 
 export function getFlagCount(flags: Array<FeatureFlag>) {
   return Object.keys(groupBy(flags, (f) => f.name)).length;
@@ -22,6 +29,25 @@ export function transformFlagValue(value: string, type: FeatureFlagType) {
       return value;
     default:
       assertUnreachable(type);
+  }
+}
+
+export function stringifyFlagValue(value: RemoteConfigValue | boolean): string {
+  if (typeof value === "boolean") {
+    return value.toString();
+  }
+
+  return stringifyRemoteConfigValue(value);
+}
+
+export function getDefaultFlagValue(type: RemoteConfigValueString | "Boolean") {
+  switch (type) {
+    case "JSON":
+    case "String":
+    case "Number":
+      return getDefaultRemoteConfigValue(type);
+    case "Boolean":
+      return DEFAULT_FEATURE_FLAG_VALUE;
   }
 }
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -26,7 +26,7 @@ export default withAuth(
 
       newUrl.pathname = `/projects/${
         tokenUser?.lastOpenProjectId ?? tokenUser?.projectIds[0]
-      }`;
+      }/flags`;
       return NextResponse.redirect(newUrl);
     }
   },

--- a/apps/web/src/pages/api/v1/data/[projectId].ts
+++ b/apps/web/src/pages/api/v1/data/[projectId].ts
@@ -75,6 +75,8 @@ export default async function getWeightsHandler(
           value: transformFlagValue(flagValue.value, flagValue.flag.type),
         };
       }),
+      // TODO: fetch non-boolean feature flags for this field
+      remoteConfig: [],
     } satisfies AbbyDataResponse;
 
     const duration = performance.now() - now;

--- a/apps/web/src/pages/api/v1/data/[projectId].ts
+++ b/apps/web/src/pages/api/v1/data/[projectId].ts
@@ -69,14 +69,22 @@ export default async function getWeightsHandler(
         name: test.name,
         weights: test.options.map((o) => o.chance.toNumber()),
       })),
-      flags: flags.map((flagValue) => {
-        return {
-          name: flagValue.flag.name,
-          value: transformFlagValue(flagValue.value, flagValue.flag.type),
-        };
-      }),
-      // TODO: fetch non-boolean feature flags for this field
-      remoteConfig: [],
+      flags: flags
+        .filter(({ flag }) => flag.type === "BOOLEAN")
+        .map((flagValue) => {
+          return {
+            name: flagValue.flag.name,
+            value: transformFlagValue(flagValue.value, flagValue.flag.type),
+          };
+        }),
+      remoteConfig: flags
+        .filter(({ flag }) => flag.type !== "BOOLEAN")
+        .map((flagValue) => {
+          return {
+            name: flagValue.flag.name,
+            value: transformFlagValue(flagValue.value, flagValue.flag.type),
+          };
+        }),
     } satisfies AbbyDataResponse;
 
     const duration = performance.now() - now;

--- a/apps/web/src/pages/devtools.tsx
+++ b/apps/web/src/pages/devtools.tsx
@@ -18,11 +18,7 @@ const { useAbby, AbbyProvider, useFeatureFlag, withDevtools, __abby__ } =
         variants: ["Dark", "Funky", "Light"],
       },
     },
-    flags: {
-      ToggleMeIfYoureExcited: "Boolean",
-      showEasterEgg: "Boolean",
-      showHeading: "Boolean",
-    },
+    flags: ["ToggleMeIfYoureExcited", "showEasterEgg", "showHeading"],
   });
 
 export const AbbyProdDevtools = withDevtools(abbyDevtools, {

--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -20,7 +20,6 @@ import { generateCodeSnippets } from "utils/snippets";
 import abbyScreenshot from "../../public/screenshot.png";
 import { NextPageWithLayout } from "./_app";
 import { DevtoolsArrow } from "components/DevtoolsArrow";
-import { PlausibleEvents } from "types/plausible-events";
 import { useTracking } from "lib/tracking";
 
 const { useAbby, AbbyProvider, useFeatureFlag, __abby__, withDevtools } =
@@ -33,9 +32,7 @@ const { useAbby, AbbyProvider, useFeatureFlag, __abby__, withDevtools } =
         variants: ["A", "B", "C"],
       },
     },
-    flags: {
-      ForceDarkTheme: "Boolean",
-    },
+    flags: ["ForceDarkTheme"],
   });
 
 const Devtools = withDevtools(DevtoolsFactory, {

--- a/apps/web/src/pages/projects/[projectId]/environments.tsx
+++ b/apps/web/src/pages/projects/[projectId]/environments.tsx
@@ -28,7 +28,7 @@ import {
   useSortable,
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
-import { Environment } from "@prisma/client";
+import { Environment, FeatureFlagType } from "@prisma/client";
 import { CSS } from "@dnd-kit/utilities";
 import { MdDragIndicator } from "react-icons/md";
 
@@ -150,6 +150,7 @@ const EnvironmentPage: NextPageWithLayout = () => {
   const { data, isLoading, isError } = trpc.flags.getFlags.useQuery(
     {
       projectId,
+      types: Object.values(FeatureFlagType),
     },
     {
       onSuccess: (data) => {

--- a/apps/web/src/pages/projects/[projectId]/remote-config.tsx
+++ b/apps/web/src/pages/projects/[projectId]/remote-config.tsx
@@ -7,24 +7,24 @@ import { trpc } from "utils/trpc";
 
 import { FeatureFlagPageContent } from "components/FlagPage";
 
-const FeatureFlagsPage: NextPageWithLayout = () => {
+const RemoteConfigPage: NextPageWithLayout = () => {
   const projectId = useProjectId();
 
   const { data, isLoading, isError } = trpc.flags.getFlags.useQuery({
     projectId,
-    types: ["BOOLEAN"],
+    types: ["JSON", "STRING", "NUMBER"],
   });
 
   if (isLoading || isError) return <FullPageLoadingSpinner />;
 
-  return <FeatureFlagPageContent data={data} type="Flags" />;
+  return <FeatureFlagPageContent data={data} type="Remote Config" />;
 };
 
-FeatureFlagsPage.getLayout = (page) => (
+RemoteConfigPage.getLayout = (page) => (
   <Layout>
-    <DashboardHeader title="Feature Flags" />
+    <DashboardHeader title="Remote Config" />
     {page}
   </Layout>
 );
 
-export default FeatureFlagsPage;
+export default RemoteConfigPage;

--- a/apps/web/src/server/services/FlagService.ts
+++ b/apps/web/src/server/services/FlagService.ts
@@ -4,6 +4,7 @@ import { getFlagCount } from "lib/flags";
 import { getProjectPaidPlan } from "lib/stripe";
 import { getLimitByPlan } from "server/common/plans";
 import { prisma } from "server/db/client";
+import { validateFlag } from "utils/validateFlags";
 
 export abstract class FlagService {
   static async createFlag({
@@ -43,6 +44,14 @@ export abstract class FlagService {
         message: `You have reached the limit of ${limits.flags} flags for your plan.`,
       });
     }
+
+    if (!validateFlag(type, value)) {
+      throw new TRPCError({
+        code: "INTERNAL_SERVER_ERROR",
+        message: `The value ${value} is not valid for the type ${type}`,
+      });
+    }
+
     const projectEnvs = await prisma.environment.findMany({
       where: {
         projectId: projectId,

--- a/apps/web/src/types/flags.ts
+++ b/apps/web/src/types/flags.ts
@@ -1,0 +1,3 @@
+import { RemoteConfigValueString } from "@tryabby/core";
+
+export type FlagValueString = RemoteConfigValueString | "Boolean";

--- a/apps/web/src/utils/snippets.ts
+++ b/apps/web/src/utils/snippets.ts
@@ -3,7 +3,7 @@ import prettier from "prettier";
 import path from "path";
 import * as fs from "fs/promises";
 import { getHighlighter } from "shiki";
-import { AbbyConfig } from "@tryabby/core";
+import { AbbyConfig, RemoteConfigValueString } from "@tryabby/core";
 import { transformDBFlagTypeToclient } from "lib/flags";
 
 // Shiki loads languages and themes using "fs" instead of "import", so Next.js
@@ -68,10 +68,17 @@ export async function generateCodeSnippets({
         };
         return acc;
       }, {} as Record<string, any>),
-      flags: flags.reduce((acc, flag) => {
-        (acc || {})[flag.name] = transformDBFlagTypeToclient(flag.type);
+      flags: flags
+        .filter((flag) => flag.type === "BOOLEAN")
+        .map((flag) => flag.name),
+      remoteConfig: flags.reduce((acc, flag) => {
+        if (flag.type !== "BOOLEAN") {
+          acc[flag.name] = transformDBFlagTypeToclient(
+            flag.type
+          ) as RemoteConfigValueString;
+        }
         return acc;
-      }, {} as AbbyConfig["flags"]),
+      }, {} as Record<string, RemoteConfigValueString>),
     } as AbbyConfig,
     null,
     2

--- a/apps/web/src/utils/validateFlags.ts
+++ b/apps/web/src/utils/validateFlags.ts
@@ -1,0 +1,25 @@
+import { FeatureFlagType } from "@prisma/client";
+
+export function validateFlag(flagType: FeatureFlagType, value: string) {
+  switch (flagType) {
+    case FeatureFlagType.BOOLEAN: {
+      return value === "true" || value === "false";
+    }
+    case FeatureFlagType.NUMBER: {
+      return !isNaN(Number(value));
+    }
+    case FeatureFlagType.STRING: {
+      return true;
+    }
+    case FeatureFlagType.JSON: {
+      try {
+        JSON.parse(value);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    }
+  }
+  // exhaustivenes test for switch
+  flagType satisfies never;
+}

--- a/packages/angular/CHANGELOG.md
+++ b/packages/angular/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/angular
 
+## 2.0.0
+
+### Major Changes
+
+- add remote config
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@5.0.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/angular",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/packages/angular/src/lib/StorageService.ts
+++ b/packages/angular/src/lib/StorageService.ts
@@ -1,6 +1,7 @@
 import {
   getABStorageKey,
   getFFStorageKey,
+  getRCStorageKey,
   type IStorageService,
 } from "@tryabby/core";
 
@@ -62,5 +63,34 @@ class FFStorageService implements IStorageService {
   }
 }
 
+class RCStorageService implements IStorageService {
+  get(projectId: string, key: string): string | null {
+    const name = `${getRCStorageKey(projectId, key)}=`;
+    const decodedCookie = decodeURIComponent(document.cookie);
+    const cookieArray = decodedCookie.split(";");
+
+    for (let i = 0; i < cookieArray.length; i++) {
+      let cookie = cookieArray[i];
+      while (cookie.charAt(0) === " ") {
+        cookie = cookie.substring(1);
+      }
+      if (cookie.indexOf(name) === 0) {
+        return cookie.substring(name.length, cookie.length);
+      }
+    }
+    return null;
+  }
+  set(projectId: string, key: string, value: string): void {
+    const token = getRCStorageKey(projectId, key);
+    document.cookie = `${token}=${value}`;
+  }
+
+  remove(projectId: string, key: string): void {
+    const token = getRCStorageKey(projectId, key);
+    document.cookie = `${token}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;`;
+  }
+}
+
 export const TestStorageService = new ABStorageService();
 export const FlagStorageService = new FFStorageService();
+export const RemoteConfigStorageService = new RCStorageService();

--- a/packages/angular/src/lib/abby.module.ts
+++ b/packages/angular/src/lib/abby.module.ts
@@ -14,12 +14,13 @@ import { DevtoolsComponent } from "./devtools.component";
 import { AbbyFlag } from "./flag.directive";
 import { AbbyTest } from "./test.directive";
 import { GetAbbyVariantPipe } from "./get-variant.pipe";
+import { GetRemoteConfigPipe } from "./get-remote-config.pipe";
 
 export const ABBY_CONFIG_TOKEN = new InjectionToken<AbbyConfig>("AbbyConfig");
 
 @NgModule({
-  declarations: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe],
-  exports: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe],
+  declarations: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe, GetRemoteConfigPipe],
+  exports: [AbbyFlag, AbbyTest, DevtoolsComponent, GetAbbyVariantPipe, GetRemoteConfigPipe],
 })
 export class AbbyModule {
   static forRoot(config: AbbyConfig): ModuleWithProviders<AbbyModule> {

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -49,6 +49,8 @@ export type InferTestNames<C extends AbbyConfig> = InferTests<C> extends Record<
   : never;
 export type InferTests<C extends AbbyConfig> = NonNullable<C["tests"]>;
 export type InferFlags<C extends AbbyConfig> = NonNullable<C["flags"]>;
+export type InferRemoteConfig<C extends AbbyConfig> = NonNullable<C["remoteConfig"]>;
+export type InferRemoteConfigName<C extends AbbyConfig> = keyof NonNullable<C["remoteConfig"]>;
 
 type PossibleFlagName<FlagName extends string> = FlagName | `!${FlagName}`;
 

--- a/packages/angular/src/lib/abby.service.ts
+++ b/packages/angular/src/lib/abby.service.ts
@@ -21,7 +21,11 @@ import {
 } from "rxjs";
 import { F } from "ts-toolbelt";
 import { AbbyLoggerService } from "./abby-logger.service";
-import { FlagStorageService, TestStorageService } from "./StorageService";
+import {
+  FlagStorageService,
+  RemoteConfigStorageService,
+  TestStorageService,
+} from "./StorageService";
 
 type LocalData<
   FlagName extends string = string,
@@ -98,6 +102,17 @@ export class AbbyService<
         set: (key: string, value: any) => {
           if (typeof window === "undefined") return;
           FlagStorageService.set(config.projectId, key, value);
+          this.cookieChanged$.next();
+        },
+      },
+      {
+        get: (key: string) => {
+          if (typeof window === "undefined") return null;
+          return RemoteConfigStorageService.get(config.projectId, key);
+        },
+        set: (key: string, value: any) => {
+          if (typeof window === "undefined") return;
+          RemoteConfigStorageService.set(config.projectId, key, value);
           this.cookieChanged$.next();
         },
       }

--- a/packages/angular/src/lib/get-remote-config.pipe.spec.ts
+++ b/packages/angular/src/lib/get-remote-config.pipe.spec.ts
@@ -1,0 +1,56 @@
+import { TestBed } from "@angular/core/testing";
+import { AbbyConfig } from "@tryabby/core";
+import { AbbyModule } from "./abby.module";
+import { GetRemoteConfigPipe } from "./get-remote-config.pipe";
+
+const mockConfig = {
+  projectId: "mock-project-id",
+  environments: [],
+  currentEnvironment: "test",
+  tests: {},
+  flags: [],
+  remoteConfig: {
+    remoteConfig1: "String",
+  },
+  settings: {},
+} satisfies AbbyConfig;
+
+const mockedData = {
+  tests: [],
+  flags: [],
+  remoteConfig: [{ name: "remoteConfig1", value: "foobar" }],
+};
+
+describe("GetRemoteConfigurationPipe", () => {
+  let pipe: GetRemoteConfigPipe<(typeof mockConfig)["remoteConfig"]>;
+
+  let fetchSpy: any;
+
+  beforeAll(() => {
+    fetchSpy = spyOn(window, "fetch");
+
+    const mockedResponse = new Response(JSON.stringify(mockedData), {
+      status: 200,
+      headers: { "Content-type": "application/json" },
+    });
+
+    fetchSpy.and.returnValue(Promise.resolve(mockedResponse));
+
+    TestBed.configureTestingModule({
+      providers: [GetRemoteConfigPipe],
+      imports: [AbbyModule.forRoot(mockConfig)],
+    });
+
+    pipe = TestBed.inject(GetRemoteConfigPipe);
+  });
+
+  it("creates pipe correctly", () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  it("returns remote config value", () => {
+    pipe.transform("remoteConfig1").subscribe((value) => {
+      expect(value).toBe("foobar");
+    });
+  });
+});

--- a/packages/angular/src/lib/get-remote-config.pipe.ts
+++ b/packages/angular/src/lib/get-remote-config.pipe.ts
@@ -1,0 +1,21 @@
+import { Pipe, PipeTransform } from "@angular/core";
+import { RemoteConfigValueString, RemoteConfigValueStringToType } from "@tryabby/core";
+import { Observable } from "rxjs";
+import { AbbyService } from "./abby.service";
+
+@Pipe({
+  name: "getAbbyRemoteConfig",
+})
+export class GetRemoteConfigPipe<RemoteConfig extends Record<string, RemoteConfigValueString>>
+  implements PipeTransform
+{
+  constructor(private abbyService: AbbyService) {}
+
+  transform<T extends Extract<keyof RemoteConfig, string>>(
+    value: T
+  ): Observable<RemoteConfigValueStringToType<RemoteConfig[T]>> {
+    return this.abbyService.getRemoteConfig(value) as Observable<
+      RemoteConfigValueStringToType<RemoteConfig[T]>
+    >;
+  }
+}

--- a/packages/angular/src/lib/get-variant.pipe.spec.ts
+++ b/packages/angular/src/lib/get-variant.pipe.spec.ts
@@ -14,7 +14,7 @@ const mockConfig = {
       variants: ["A", "B", "C", "D"],
     },
   },
-  flags: {},
+  flags: [],
   settings: {},
 } satisfies AbbyConfig;
 
@@ -26,15 +26,15 @@ const mockedData = {
     },
   ],
   flags: [],
+  remoteConfig: [],
 };
 
 describe("GetAbbyVariantPipe", () => {
   let pipe: GetAbbyVariantPipe<keyof (typeof mockConfig)["tests"], (typeof mockConfig)["tests"]>;
   let service: AbbyService<
-    keyof (typeof mockConfig)["flags"],
+    (typeof mockConfig)["flags"][number],
     keyof (typeof mockConfig)["tests"],
-    (typeof mockConfig)["tests"],
-    (typeof mockConfig)["flags"]
+    (typeof mockConfig)["tests"]
   >;
 
   let fetchSpy: any;
@@ -54,7 +54,7 @@ describe("GetAbbyVariantPipe", () => {
       imports: [AbbyModule.forRoot(mockConfig)],
     });
 
-    service = TestBed.inject(AbbyService);
+    service = TestBed.inject(AbbyService) as typeof service;
     pipe = TestBed.inject(GetAbbyVariantPipe);
   });
 

--- a/packages/angular/src/public-api.ts
+++ b/packages/angular/src/public-api.ts
@@ -8,4 +8,5 @@ export * from "./lib/test.directive";
 export * from "./lib/flag.directive";
 export * from "./lib/get-variant.pipe";
 export * from "./lib/devtools.component";
+export * from "./lib/get-remote-config.pipe";
 export { defineConfig } from "@tryabby/core";

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tryabby/cli
 
+## 1.0.0
+
+### Major Changes
+
+- add remote config
+
 ## 0.3.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/cli",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "private": false,
   "main": "./dist/index.js",
   "bin": {

--- a/packages/cli/src/pull.ts
+++ b/packages/cli/src/pull.ts
@@ -28,7 +28,8 @@ export function mergeConfigs(localConfig: AbbyConfig, remoteConfig: PullAbbyConf
     ...localConfig,
     environments: Array.from(new Set([...localConfig.environments, ...remoteConfig.environments])),
     tests: deepmerge(localConfig.tests ?? {}, remoteConfig.tests ?? {}),
-    flags: deepmerge(localConfig.flags ?? {}, remoteConfig.flags ?? {}),
+    flags: deepmerge(localConfig.flags ?? [], remoteConfig.flags ?? []),
+    remoteConfig: deepmerge(localConfig.remoteConfig ?? {}, remoteConfig.remoteConfig ?? {}),
   } satisfies AbbyConfig;
 }
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tryabby/core
 
+## 5.0.0
+
+### Major Changes
+
+- add remote config
+
 ## 4.2.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/core",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -1,10 +1,12 @@
 import { F } from "ts-toolbelt";
-import { ABConfig, AbbyConfig } from ".";
+import { ABConfig, AbbyConfig, RemoteConfigValueString } from ".";
 
 export function defineConfig<
   FlagName extends string,
   Tests extends Record<string, ABConfig>,
   Flags extends FlagName[],
->(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags>>) {
+  RemoteConfigName extends string,
+  RemoteConfig extends Record<RemoteConfigName, RemoteConfigValueString>,
+>(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags, string[], RemoteConfigName, RemoteConfig>>) {
   return config;
 }

--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -4,9 +4,8 @@ import { ABConfig, AbbyConfig, RemoteConfigValueString } from ".";
 export function defineConfig<
   FlagName extends string,
   Tests extends Record<string, ABConfig>,
-  Flags extends FlagName[],
-  RemoteConfigName extends string,
   RemoteConfig extends Record<RemoteConfigName, RemoteConfigValueString>,
->(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags, string[], RemoteConfigName, RemoteConfig>>) {
+  RemoteConfigName extends Extract<keyof RemoteConfig, string>,
+>(config: F.Narrow<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>>) {
   return config;
 }

--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -1,10 +1,10 @@
 import { F } from "ts-toolbelt";
-import { ABConfig, AbbyConfig, FlagValueString } from ".";
+import { ABConfig, AbbyConfig } from ".";
 
 export function defineConfig<
   FlagName extends string,
   Tests extends Record<string, ABConfig>,
-  Flags extends Record<FlagName, FlagValueString>,
+  Flags extends FlagName[],
 >(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags>>) {
   return config;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -205,7 +205,7 @@ export class Abby<
         },
         {} as Record<string, boolean>
       ),
-      remoteConfig: data.remoteConfig.reduce(
+      remoteConfig: (data.remoteConfig ?? []).reduce(
         (acc, { name, value }) => {
           acc[name] = value;
           return acc;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -165,7 +165,7 @@ export class Abby<
     this.init(data);
   }
 
-  async getProjectDataAsync(): Promise<LocalData<FlagName, TestName>> {
+  async getProjectDataAsync(): Promise<LocalData<FlagName, TestName, RemoteConfigName>> {
     this.log(`getProjectDataAsync()`);
 
     if (!this.dataInitialized) {
@@ -220,7 +220,7 @@ export class Abby<
    * This also includes the overrides from the dev tools and the local overrides
    * @returns the local data
    */
-  getProjectData(): LocalData<FlagName, TestName> {
+  getProjectData(): LocalData<FlagName, TestName, RemoteConfigName> {
     this.log(`getProjectData()`);
 
     return {

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -3,3 +3,4 @@ export const ABBY_BASE_URL = "https://www.tryabby.com/";
 export const ABBY_AB_STORAGE_PREFIX = "__abby__ab__";
 export const ABBY_FF_STORAGE_PREFIX = "__abby__ff__";
 export const ABBY_INSTANCE_KEY = "__abby_instance__";
+export const DEFAULT_FEATURE_FLAG_VALUE = false;

--- a/packages/core/src/shared/constants.ts
+++ b/packages/core/src/shared/constants.ts
@@ -2,5 +2,6 @@ export const DOCS_URL = "https://docs.tryabby.com/";
 export const ABBY_BASE_URL = "https://www.tryabby.com/";
 export const ABBY_AB_STORAGE_PREFIX = "__abby__ab__";
 export const ABBY_FF_STORAGE_PREFIX = "__abby__ff__";
+export const ABBY_RC_STORAGE_PREFIX = "__abby__rc__";
 export const ABBY_INSTANCE_KEY = "__abby_instance__";
 export const DEFAULT_FEATURE_FLAG_VALUE = false;

--- a/packages/core/src/shared/helpers.ts
+++ b/packages/core/src/shared/helpers.ts
@@ -1,3 +1,5 @@
+import { F } from "ts-toolbelt";
+import { FlagValueStringToType } from "../../dist";
 import { ABBY_AB_STORAGE_PREFIX, ABBY_FF_STORAGE_PREFIX } from "./constants";
 import { FlagValue, FlagValueString } from "./schemas";
 

--- a/packages/core/src/shared/helpers.ts
+++ b/packages/core/src/shared/helpers.ts
@@ -1,7 +1,5 @@
-import { F } from "ts-toolbelt";
-import { FlagValueStringToType } from "../../dist";
 import { ABBY_AB_STORAGE_PREFIX, ABBY_FF_STORAGE_PREFIX } from "./constants";
-import { FlagValue, FlagValueString } from "./schemas";
+import { RemoteConfigValue, RemoteConfigValueString } from "./schemas";
 
 export function getABStorageKey(projectId: string, testName: string): string {
   return `${ABBY_AB_STORAGE_PREFIX}${projectId}_${testName}`;
@@ -15,16 +13,14 @@ export function assertUnreachable(x: never): never {
   throw new Error("Reached unreachable code");
 }
 
-export function flagStringToType({
+export function remoteConfigStringToType({
   stringifiedValue,
-  flagType,
+  remoteConfigType,
 }: {
   stringifiedValue: string;
-  flagType: FlagValueString;
-}): FlagValue {
-  switch (flagType) {
-    case "Boolean":
-      return stringifiedValue === "true";
+  remoteConfigType: RemoteConfigValueString;
+}): RemoteConfigValue {
+  switch (remoteConfigType) {
     case "String":
       return stringifiedValue;
     case "Number":
@@ -32,14 +28,14 @@ export function flagStringToType({
     case "JSON":
       return JSON.parse(stringifiedValue);
     default:
-      assertUnreachable(flagType);
+      assertUnreachable(remoteConfigType);
   }
 }
 
-export function getDefaultFlagValue(flagType: FlagValueString): FlagValue {
-  switch (flagType) {
-    case "Boolean":
-      return false;
+export function getDefaultRemoteConfigValue(
+  remoteConfigType: RemoteConfigValueString
+): RemoteConfigValue {
+  switch (remoteConfigType) {
     case "String":
       return "";
     case "Number":
@@ -47,13 +43,12 @@ export function getDefaultFlagValue(flagType: FlagValueString): FlagValue {
     case "JSON":
       return {};
     default:
-      assertUnreachable(flagType);
+      assertUnreachable(remoteConfigType);
   }
 }
 
-export function stringifyFlagValue(value: FlagValue) {
+export function stringifyRemoteConfigValue(value: RemoteConfigValue) {
   switch (typeof value) {
-    case "boolean":
     case "number":
       return value.toString();
     case "string":

--- a/packages/core/src/shared/helpers.ts
+++ b/packages/core/src/shared/helpers.ts
@@ -1,4 +1,8 @@
-import { ABBY_AB_STORAGE_PREFIX, ABBY_FF_STORAGE_PREFIX } from "./constants";
+import {
+  ABBY_AB_STORAGE_PREFIX,
+  ABBY_FF_STORAGE_PREFIX,
+  ABBY_RC_STORAGE_PREFIX,
+} from "./constants";
 import { RemoteConfigValue, RemoteConfigValueString } from "./schemas";
 
 export function getABStorageKey(projectId: string, testName: string): string {
@@ -7,6 +11,10 @@ export function getABStorageKey(projectId: string, testName: string): string {
 
 export function getFFStorageKey(projectId: string, flagName: string): string {
   return `${ABBY_FF_STORAGE_PREFIX}${projectId}_${flagName}`;
+}
+
+export function getRCStorageKey(projectId: string, remoteConfigName: string): string {
+  return `${ABBY_RC_STORAGE_PREFIX}${projectId}_${remoteConfigName}`;
 }
 
 export function assertUnreachable(x: never): never {

--- a/packages/core/src/shared/schemas.ts
+++ b/packages/core/src/shared/schemas.ts
@@ -46,7 +46,13 @@ export const abbyConfigSchema = z.object({
         .optional(),
       remoteConfig: z
         .object({
-          defaultValues: z.record(remoteConfigValueStringSchema, remoteConfigValue).optional(),
+          defaultValues: z
+            .object({
+              String: z.string(),
+              Number: z.number(),
+              JSON: z.record(z.string(), z.unknown()),
+            })
+            .partial(),
           devOverrides: z.record(z.string(), remoteConfigValue).optional(),
         })
         .optional(),

--- a/packages/core/src/shared/schemas.ts
+++ b/packages/core/src/shared/schemas.ts
@@ -10,16 +10,14 @@ export const abbyEventSchema = z.object({
 
 export type AbbyEvent = z.infer<typeof abbyEventSchema>;
 
-export const flagValue = z.union([
-  z.boolean(),
+export const remoteConfigValue = z.union([
   z.string(),
   z.number(),
   z.record(z.string(), z.unknown()),
 ]);
 
-export const flagValueStringSchema = z.union([
+export const remoteConfigValueStringSchema = z.union([
   z.literal("String"),
-  z.literal("Boolean"),
   z.literal("Number"),
   z.literal("JSON"),
 ]);
@@ -37,12 +35,19 @@ export const abbyConfigSchema = z.object({
     )
     .optional(),
   flags: z.array(z.string()).optional(),
+  remoteConfig: z.record(remoteConfigValueStringSchema).optional(),
   settings: z
     .object({
       flags: z
         .object({
           defaultValue: z.boolean().optional(),
           devOverrides: z.record(z.string(), z.boolean()).optional(),
+        })
+        .optional(),
+      remoteConfig: z
+        .object({
+          defaultValues: z.record(remoteConfigValueStringSchema, remoteConfigValue).optional(),
+          devOverrides: z.record(z.string(), remoteConfigValue).optional(),
         })
         .optional(),
     })
@@ -54,14 +59,12 @@ export type AbbyConfigFile = z.infer<typeof abbyConfigSchema>;
 
 export type PullAbbyConfigResponse = Pick<AbbyConfigFile, "environments" | "flags" | "tests">;
 
-export type FlagValue = z.infer<typeof flagValue>;
+export type RemoteConfigValue = z.infer<typeof remoteConfigValue>;
 
-export type FlagValueString = z.infer<typeof flagValueStringSchema>;
+export type RemoteConfigValueString = z.infer<typeof remoteConfigValueStringSchema>;
 
-export type FlagValueStringToType<T extends FlagValueString> = T extends "String"
+export type RemoteConfigValueStringToType<T extends RemoteConfigValueString> = T extends "String"
   ? string
-  : T extends "Boolean"
-  ? boolean
   : T extends "Number"
   ? number
   : T extends "JSON"

--- a/packages/core/src/shared/schemas.ts
+++ b/packages/core/src/shared/schemas.ts
@@ -36,13 +36,13 @@ export const abbyConfigSchema = z.object({
       })
     )
     .optional(),
-  flags: z.record(flagValueStringSchema).optional(),
+  flags: z.array(z.string()).optional(),
   settings: z
     .object({
       flags: z
         .object({
-          defaultValues: z.record(z.string(), flagValue).optional(),
-          devOverrides: z.record(z.string(), flagValue).optional(),
+          defaultValue: z.boolean().optional(),
+          devOverrides: z.record(z.string(), z.boolean()).optional(),
         })
         .optional(),
     })

--- a/packages/core/src/shared/schemas.ts
+++ b/packages/core/src/shared/schemas.ts
@@ -57,7 +57,10 @@ export const abbyConfigSchema = z.object({
 
 export type AbbyConfigFile = z.infer<typeof abbyConfigSchema>;
 
-export type PullAbbyConfigResponse = Pick<AbbyConfigFile, "environments" | "flags" | "tests">;
+export type PullAbbyConfigResponse = Pick<
+  AbbyConfigFile,
+  "environments" | "flags" | "tests" | "remoteConfig"
+>;
 
 export type RemoteConfigValue = z.infer<typeof remoteConfigValue>;
 

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -1,5 +1,5 @@
 import { Key } from "ts-toolbelt/out/Any/Key";
-import { ABConfig } from "..";
+import { ABConfig, RemoteConfigValue } from "..";
 
 export enum AbbyEventType {
   PING,
@@ -15,6 +15,7 @@ export type AbbyDataResponse = {
     name: string;
     value: boolean;
   }>;
+  remoteConfig: Array<{ name: string; value: RemoteConfigValue }>;
 };
 
 export type LegacyAbbyDataResponse = {

--- a/packages/core/src/shared/types.ts
+++ b/packages/core/src/shared/types.ts
@@ -1,6 +1,5 @@
 import { Key } from "ts-toolbelt/out/Any/Key";
 import { ABConfig } from "..";
-import { FlagValue } from "./schemas";
 
 export enum AbbyEventType {
   PING,
@@ -14,7 +13,7 @@ export type AbbyDataResponse = {
   }>;
   flags: Array<{
     name: string;
-    value: FlagValue;
+    value: boolean;
   }>;
 };
 
@@ -30,4 +29,3 @@ export type ExtractVariants<
   TestName extends Key,
   Tests extends Record<TestName, ABConfig>,
 > = Tests[TestName]["variants"][number];
-

--- a/packages/core/tests/base.test.ts
+++ b/packages/core/tests/base.test.ts
@@ -41,7 +41,7 @@ describe("Abby", () => {
       },
     });
 
-    abby.init({ flags: [], tests: [{ name: "a", weights: [0, 1] }] });
+    abby.init({ flags: [], tests: [{ name: "a", weights: [0, 1] }], remoteConfig: [] });
     // const variant = abby.getTestVariant("a");
     expect(abby.getTestVariant("a")).toBe(variants[1]);
   });
@@ -50,25 +50,33 @@ describe("Abby", () => {
     const abby = new Abby({
       environments: [],
       projectId: "abc",
-      flags: {
-        flag1: "String",
-        flag2: "Boolean",
-      },
+      flags: ["flag1"],
     });
 
     await abby.loadProjectData();
 
     expect(abby.getFeatureFlag("flag1")).toBe(true);
+  });
 
-    expect(abby.getFeatureFlag("flag2")).toEqual("test");
+  it("gets a remote config", async () => {
+    const abby = new Abby({
+      environments: [],
+      projectId: "foo",
+      remoteConfig: { remoteConfig1: "String" },
+    });
+
+    await abby.loadProjectData();
+
+    expect(abby.getRemoteConfig("remoteConfig1")).toBe("asdf");
   });
 
   it("uses the devOverrides", () => {
     const abby = new Abby({
       environments: [],
       projectId: "",
-      flags: {
-        flag1: "Boolean",
+      flags: ["flag1"],
+      remoteConfig: {
+        remoteConfig1: "String",
       },
       settings: {
         flags: {
@@ -76,16 +84,27 @@ describe("Abby", () => {
             flag1: false,
           },
         },
+        remoteConfig: {
+          devOverrides: {
+            remoteConfig1: "foobar",
+          },
+        },
       },
     });
 
-    abby.init({ flags: [{ name: "flag1", value: true }], tests: [] });
+    abby.init({
+      flags: [{ name: "flag1", value: true }],
+      tests: [],
+      remoteConfig: [{ name: "remoteConfig1", value: "asdf" }],
+    });
 
     process.env.NODE_ENV = "development";
     expect(abby.getFeatureFlag("flag1")).toBe(false);
+    expect(abby.getRemoteConfig("remoteConfig1")).toBe("foobar");
 
     process.env.NODE_ENV = "production";
     expect(abby.getFeatureFlag("flag1")).toBe(true);
+    expect(abby.getRemoteConfig("remoteConfig1")).toBe("asdf");
   });
 
   it("updates a local variant in dev mode", () => {
@@ -113,19 +132,32 @@ describe("Abby", () => {
     const abby = new Abby({
       environments: [],
       projectId: "",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
     });
 
-    abby.init({ flags: [{ name: "flag1", value: true }], tests: [] });
+    abby.init({ flags: [{ name: "flag1", value: true }], tests: [], remoteConfig: [] });
 
     expect(abby.getFeatureFlag("flag1")).toBe(true);
 
     abby.updateFlag("flag1", false);
 
     expect(abby.getFeatureFlag("flag1")).toBe(false);
+  });
+
+  it("updates local remote config", () => {
+    const abby = new Abby({
+      environments: [],
+      projectId: "",
+      remoteConfig: { remoteConfig1: "String" },
+    });
+
+    abby.init({ flags: [], tests: [], remoteConfig: [{ name: "remoteConfig1", value: "foo" }] });
+
+    expect(abby.getRemoteConfig("remoteConfig1")).toBe("foo");
+
+    abby.updateRemoteConfig("remoteConfig1", "bar");
+
+    expect(abby.getRemoteConfig("remoteConfig1")).toBe("bar");
   });
 });
 

--- a/packages/core/tests/defineConfig.test.ts
+++ b/packages/core/tests/defineConfig.test.ts
@@ -1,12 +1,12 @@
-import { Abby } from "../dist";
+import { Abby } from "../src";
 import { defineConfig } from "../src/defineConfig";
 
 describe("defineConfig", () => {
   const cfg = defineConfig({
     projectId: "xd",
     environments: ["development", "production"],
-    flags: {
-      a: "Boolean",
+    flags: ["a"],
+    remoteConfig: {
       b: "String",
       c: "Number",
       d: "JSON",
@@ -21,11 +21,11 @@ describe("defineConfig", () => {
   const abby = new Abby(cfg);
 
   it("produces proper types", () => {
-    expectTypeOf(abby.getFeatureFlag).parameter(0).toEqualTypeOf<"a" | "b" | "c" | "d">();
+    expectTypeOf(abby.getFeatureFlag).parameter(0).toEqualTypeOf<"a">();
     expectTypeOf(abby.getFeatureFlag("a")).toEqualTypeOf<boolean>();
-    expectTypeOf(abby.getFeatureFlag("b")).toEqualTypeOf<string>();
-    expectTypeOf(abby.getFeatureFlag("c")).toEqualTypeOf<number>();
-    expectTypeOf(abby.getFeatureFlag("d")).toEqualTypeOf<Record<string, unknown>>();
+    expectTypeOf(abby.getRemoteConfig("b")).toEqualTypeOf<string>();
+    expectTypeOf(abby.getRemoteConfig("c")).toEqualTypeOf<number>();
+    expectTypeOf(abby.getRemoteConfig("d")).toEqualTypeOf<Record<string, unknown>>();
 
     expectTypeOf(abby.getVariants).parameter(0).toEqualTypeOf<"abTest">();
   });

--- a/packages/core/tests/mocks/handlers.ts
+++ b/packages/core/tests/mocks/handlers.ts
@@ -17,11 +17,8 @@ const returnData: AbbyDataResponse = {
       name: "flag1",
       value: true,
     },
-    {
-      name: "flag2",
-      value: "test",
-    },
   ],
+  remoteConfig: [{ name: "remoteConfig1", value: "asdf" }],
 };
 
 export const handlers = [

--- a/packages/core/tests/types.test.ts
+++ b/packages/core/tests/types.test.ts
@@ -1,15 +1,12 @@
-import { AbbyConfig, FlagValueStringToType } from "../dist";
-import { Abby } from "../src/index";
+import { RemoteConfigValueStringToType } from "../dist";
+import { Abby, AbbyConfig } from "../src/index";
 
 describe("types", () => {
   it("produces proper types", () => {
     const abby = new Abby({
       environments: [""],
       projectId: "",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
       tests: {
         test1: {
           variants: ["firstVariant", "secondVariant"],
@@ -18,11 +15,13 @@ describe("types", () => {
           variants: ["some-random-string", "abc"],
         },
       },
+      remoteConfig: { remoteConfig1: "String" },
     });
 
     assertType<boolean>(abby.getFeatureFlag("flag1"));
-    assertType<string>(abby.getFeatureFlag("flag2"));
-    expectTypeOf(abby.getFeatureFlag).parameter(0).toEqualTypeOf<"flag1" | "flag2">();
+    assertType<string>(abby.getRemoteConfig("remoteConfig1"));
+    expectTypeOf(abby.getFeatureFlag).parameter(0).toEqualTypeOf<"flag1">();
+    expectTypeOf(abby.getRemoteConfig).parameter(0).toEqualTypeOf<"remoteConfig1">();
 
     assertType<"firstVariant" | "secondVariant">(abby.getTestVariant("test1"));
 
@@ -31,30 +30,20 @@ describe("types", () => {
     // This is the potential type of the devOverrides
     type DevOverrides = NonNullable<
       NonNullable<
-        NonNullable<
-          AbbyConfig<
-            "flag1" | "flag2",
-            {},
-            {
-              flag1: "Boolean";
-              flag2: "String";
-            }
-          >["settings"]
-        >["flags"]
+        NonNullable<AbbyConfig<"flag1", {}, ["flag1"]>["settings"]>["flags"]
       >["devOverrides"]
     >;
 
     expectTypeOf<DevOverrides>().toEqualTypeOf<{
       flag1?: boolean;
-      flag2?: string;
     }>();
   });
 });
 
 describe("Type Helpers", () => {
   it("converts the strings properly", () => {
-    expectTypeOf<FlagValueStringToType<"String">>().toEqualTypeOf<string>();
-    expectTypeOf<FlagValueStringToType<"Boolean">>().toEqualTypeOf<boolean>();
-    expectTypeOf<FlagValueStringToType<"Number">>().toEqualTypeOf<number>();
+    expectTypeOf<RemoteConfigValueStringToType<"String">>().toEqualTypeOf<string>();
+    expectTypeOf<RemoteConfigValueStringToType<"JSON">>().toEqualTypeOf<Record<string, unknown>>();
+    expectTypeOf<RemoteConfigValueStringToType<"Number">>().toEqualTypeOf<number>();
   });
 });

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @tryabby/devtools
 
+## 5.0.0
+
+### Major Changes
+
+- add remote config
+
 ## 4.1.0
 
 ### Minor Changes

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/devtools",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "type": "module",
   "files": [
     "dist"

--- a/packages/devtools/src/Devtools.svelte
+++ b/packages/devtools/src/Devtools.svelte
@@ -19,7 +19,7 @@
 
   export let shortcut: Shortcut | Array<Shortcut> = ["command+.", "ctrl+."];
 
-  export let abby: Abby<any, any, any, any>;
+  export let abby: Abby<any, any, any, any, any>;
 
   let show = false;
 
@@ -61,7 +61,7 @@
     window.removeEventListener("message", onMessage);
   });
 
-  const { flags, tests } = abby?.getProjectData() ?? {};
+  const { flags, tests, remoteConfig } = abby?.getProjectData() ?? {};
 
   const [send, receive] = crossfade({
     duration: 200,
@@ -111,35 +111,38 @@
     <hr />
     <h2>Flags:</h2>
     {#each Object.entries(flags) as [flagName, flagValue]}
-      {#if typeof flagValue === "boolean"}
-        <Switch
-          id={flagName}
-          label={flagName}
-          checked={flagValue}
-          onChange={(newValue) => {
-            window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
-            abby.updateFlag(flagName, newValue);
-          }}
-        />
-      {:else if typeof flagValue === "string" || typeof flagValue === "number"}
+      <Switch
+        id={flagName}
+        label={flagName}
+        checked={flagValue}
+        onChange={(newValue) => {
+          window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
+          abby.updateFlag(flagName, newValue);
+        }}
+      />
+    {/each}
+    <hr />
+    <h2>Remote Config:</h2>
+    {#each Object.entries(remoteConfig) as [remoteConfigName, remoteConfigValue]}
+      {#if typeof remoteConfigValue === "string" || typeof remoteConfigValue === "number"}
         <Input
-          id={flagName}
-          label={flagName}
-          type={typeof flagValue === "string" ? "text" : "number"}
-          value={flagValue}
+          id={remoteConfigName}
+          label={remoteConfigName}
+          type={typeof remoteConfigValue === "string" ? "text" : "number"}
+          value={remoteConfigValue}
           onChange={(newValue) => {
-            window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
-            abby.updateFlag(flagName, newValue);
+            window.postMessage({ type: "abby:update-flag", remoteConfigName, newValue }, "*");
+            abby.updateRemoteConfig(remoteConfigName, newValue);
           }}
         />
-      {:else if typeof flagValue === "object"}
+      {:else if typeof remoteConfigValue === "object"}
         <div style="display: flex; flex-direction: column; margin: 10px 0;">
-          <p style="margin-bottom: 5px;">{flagName}</p>
+          <p style="margin-bottom: 5px;">{remoteConfigName}</p>
           <Modal
-            value={flagValue}
+            value={remoteConfigValue}
             onChange={(newValue) => {
-              window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
-              abby.updateFlag(flagName, newValue);
+              window.postMessage({ type: "abby:update-flag", remoteConfigName, newValue }, "*");
+              abby.updateRemoteConfig(remoteConfigName, newValue);
             }}
           />
         </div>

--- a/packages/devtools/src/components/Input.svelte
+++ b/packages/devtools/src/components/Input.svelte
@@ -40,6 +40,7 @@
     transition: all 150ms ease;
     margin-top: 5px;
     color: var(--pink);
+    box-sizing: border-box;
 
     &:required:invalid {
       color: #5a667f;

--- a/packages/next/CHANGELOG.md
+++ b/packages/next/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/next
 
+## 5.0.0
+
+### Major Changes
+
+- add remote config
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/react@5.0.0
+
 ## 4.1.1
 
 ### Patch Changes

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/next",
-  "version": "4.1.1",
+  "version": "5.0.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/next/src/index.tsx
+++ b/packages/next/src/index.tsx
@@ -5,7 +5,7 @@ import {
   withDevtoolsFunction,
   ABTestReturnValue,
 } from "@tryabby/react";
-import { AbbyDataResponse, FlagValueString, getABStorageKey } from "@tryabby/core";
+import { AbbyDataResponse, getABStorageKey, RemoteConfigValueString } from "@tryabby/core";
 import type { F } from "ts-toolbelt";
 import { ABBY_DATA_KEY, withAbby } from "./withAbby";
 import { HttpService } from "@tryabby/core";
@@ -21,17 +21,27 @@ export function createAbby<
   FlagName extends string,
   TestName extends string,
   Tests extends Record<TestName, ABConfig>,
-  Flags extends Record<FlagName, FlagValueString> = Record<FlagName, FlagValueString>,
->(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags>>) {
+  RemoteConfig extends Record<RemoteConfigName, RemoteConfigValueString>,
+  RemoteConfigName extends Extract<keyof RemoteConfig, string>,
+  ConfigType extends AbbyConfig<
+    FlagName,
+    Tests,
+    string[],
+    RemoteConfigName,
+    RemoteConfig
+  > = AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>,
+>(config: F.Narrow<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>>) {
   const {
     AbbyProvider,
     useAbby,
     useFeatureFlag,
     getFeatureFlagValue,
+    useRemoteConfig,
+    getRemoteConfig,
     __abby__,
     getVariants,
     withDevtools,
-  } = baseCreateAbby<FlagName, TestName, Tests, Flags>(config);
+  } = baseCreateAbby<FlagName, TestName, Tests, RemoteConfig, RemoteConfigName, ConfigType>(config);
 
   const abbyApiHandler =
     <HandlerType extends NextApiHandler | NextMiddleware>(handler: HandlerType) =>
@@ -67,6 +77,8 @@ export function createAbby<
     useFeatureFlag,
     withAbby: withAbby(config as AbbyConfig<FlagName, Tests>, __abby__),
     getFeatureFlagValue,
+    useRemoteConfig,
+    getRemoteConfig,
     __abby__,
     getVariants,
     withDevtools: withDevtools as withDevtoolsFunction,

--- a/packages/next/src/withAbby.tsx
+++ b/packages/next/src/withAbby.tsx
@@ -1,8 +1,4 @@
-import type {
-  AppContextType,
-  AppPropsType,
-  NextComponentType,
-} from "next/dist/shared/lib/utils";
+import type { AppContextType, AppPropsType, NextComponentType } from "next/dist/shared/lib/utils";
 import { AbbyConfig } from "@tryabby/react";
 import { NextRouter } from "next/router";
 import { HttpService } from "@tryabby/core";
@@ -13,10 +9,10 @@ import { PromiseCache } from "./cache";
 export const ABBY_DATA_KEY = "__ABBY_PROJECT_DATA__";
 
 export function withAbby<
-  Config extends Pick<AbbyConfig, "apiUrl" | "projectId" | "currentEnvironment">
+  Config extends Pick<AbbyConfig, "apiUrl" | "projectId" | "currentEnvironment">,
 >(
   { apiUrl, projectId, currentEnvironment }: Config,
-  abbyInstance: Abby<any, any, any, any>,
+  abbyInstance: Abby<any, any, any, any, any>,
   preloadAll = true
 ) {
   const promiseCache = new PromiseCache<AbbyDataResponse | null>();
@@ -48,18 +44,12 @@ export function withAbby<
         pageProps[ABBY_DATA_KEY] = abbyData;
       }
 
-      abbyInstance.setLocalOverrides(
-        appOrPageCtx.ctx.req?.headers.cookie ?? ""
-      );
+      abbyInstance.setLocalOverrides(appOrPageCtx.ctx.req?.headers.cookie ?? "");
 
       // Run the wrapped component's getInitialProps function.
       if (AppOrPage.getInitialProps) {
-        const originalProps = await AppOrPage.getInitialProps(
-          appOrPageCtx as any
-        );
-        const originalPageProps = isApp
-          ? originalProps.pageProps ?? {}
-          : originalProps;
+        const originalProps = await AppOrPage.getInitialProps(appOrPageCtx as any);
+        const originalPageProps = isApp ? originalProps.pageProps ?? {} : originalProps;
 
         pageProps = {
           ...originalPageProps,

--- a/packages/next/tests/mocks/handlers.ts
+++ b/packages/next/tests/mocks/handlers.ts
@@ -19,7 +19,13 @@ const returnData: AbbyDataResponse = {
     },
     {
       name: "flag2",
-      value: "test",
+      value: false,
+    },
+  ],
+  remoteConfig: [
+    {
+      name: "remoteConfig1",
+      value: "FooBar",
     },
   ],
 };

--- a/packages/next/tests/types.test.tsx
+++ b/packages/next/tests/types.test.tsx
@@ -55,10 +55,7 @@ describe("useFeatureFlag", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        test: "Boolean",
-        test1: "String",
-      },
+      flags: ["test"],
     });
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
@@ -74,10 +71,7 @@ describe("useFeatureFlag", () => {
       environments: [],
       projectId: "123",
       currentEnvironment: "test",
-      flags: {
-        test: "Boolean",
-        test1: "String",
-      },
+      flags: ["test"],
       tests: {
         a: {
           variants: ["a1", "a2"],
@@ -99,10 +93,7 @@ describe("useFeatureFlag", () => {
       environments: [],
       projectId: "123",
       currentEnvironment: "test",
-      flags: {
-        test: "Boolean",
-        test1: "String",
-      },
+      flags: ["test"],
       tests: {
         a: {
           variants: ["a1", "a2"],
@@ -147,5 +138,37 @@ describe("useFeatureFlag", () => {
     const apiHandler = withAbbyApiHandler((req, res) => {});
 
     expectTypeOf(apiHandler).parameters.toEqualTypeOf<[NextApiRequest, NextApiResponse]>();
+  });
+});
+
+describe("useRemoteConfig", () => {
+  it.skip("has the correct typings", () => {
+    const { AbbyProvider, useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        stringRc: "String",
+        numberRc: "Number",
+        jsonRc: "JSON",
+      },
+    });
+
+    expectTypeOf(useRemoteConfig).parameter(0).toEqualTypeOf<"stringRc" | "numberRc" | "jsonRc">();
+
+    const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
+
+    const { result: stringRcResult } = renderHook(() => useRemoteConfig("stringRc"), {
+      wrapper,
+    });
+    const { result: numberRcResult } = renderHook(() => useRemoteConfig("numberRc"), {
+      wrapper,
+    });
+    const { result: jsonRcResult } = renderHook(() => useRemoteConfig("jsonRc"), {
+      wrapper,
+    });
+
+    expectTypeOf(stringRcResult.current).toEqualTypeOf<string>();
+    expectTypeOf(numberRcResult.current).toEqualTypeOf<number>();
+    expectTypeOf(jsonRcResult.current).toEqualTypeOf<Record<string, unknown>>();
   });
 });

--- a/packages/next/tests/useAbby.test.tsx
+++ b/packages/next/tests/useAbby.test.tsx
@@ -34,10 +34,7 @@ describe("useAbby", () => {
           variants: ["SimonsText", "MatthiasText", "TomsText", "TimsText"],
         },
       },
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
     });
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
@@ -50,19 +47,13 @@ describe("useAbby", () => {
 
     expectTypeOf(result.current.variant).toEqualTypeOf<"OldFooter" | "NewFooter">();
 
-    expectTypeOf(useFeatureFlag).parameters.toEqualTypeOf<["flag1" | "flag2"]>();
+    expectTypeOf(useFeatureFlag).parameters.toEqualTypeOf<["flag1"]>();
 
     const { result: ffResult } = renderHook(() => useFeatureFlag("flag1"), {
       wrapper,
     });
 
     expectTypeOf(ffResult.current).toEqualTypeOf<boolean>();
-
-    const { result: ff2Result } = renderHook(() => useFeatureFlag("flag2"), {
-      wrapper,
-    });
-
-    expectTypeOf(ff2Result.current).toEqualTypeOf<string>();
   });
 
   it("uses lookup object when retrieving AB test variant", () => {

--- a/packages/next/tests/withAbby.test.tsx
+++ b/packages/next/tests/withAbby.test.tsx
@@ -18,7 +18,7 @@ describe("withAbby", () => {
       environments: [],
       projectId: "123",
       tests: {},
-      flags: { flag1: "Boolean", flag2: "String" },
+      flags: ["flag1"],
     });
 
     const Component = withAbby(() => <></>);
@@ -35,7 +35,6 @@ describe("withAbby", () => {
 
     render(<Component {...props} />);
     expect(getFeatureFlagValue("flag1")).toBe(true);
-    expect(getFeatureFlagValue("flag2")).toBe("test");
   });
 
   it("seeds the flags in development with the cookies", async () => {
@@ -45,7 +44,7 @@ describe("withAbby", () => {
       environments: [],
       projectId: "123",
       tests: {},
-      flags: { flag1: "Boolean", flag2: "String" },
+      flags: ["flag1"],
     });
 
     const Component = withAbby(() => <></>);
@@ -56,7 +55,7 @@ describe("withAbby", () => {
       ctx: {
         req: {
           headers: {
-            cookie: `${ABBY_FF_STORAGE_PREFIX}123_flag1=false; ${ABBY_FF_STORAGE_PREFIX}123_flag2=test`,
+            cookie: `${ABBY_FF_STORAGE_PREFIX}123_flag1=false;`,
           },
         },
       },
@@ -64,6 +63,28 @@ describe("withAbby", () => {
 
     render(<Component {...props} />);
     expect(getFeatureFlagValue("flag1")).toBe(false);
-    expect(getFeatureFlagValue("flag2")).toBe("test");
+  });
+
+  it("returns correct value for remoteConfig", async () => {
+    const { withAbby, getRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        remoteConfig1: "String",
+      },
+    });
+    const Component = withAbby(() => <></>);
+
+    const props = await (Component as any).getInitialProps({
+      Component: () => {},
+      ctx: {
+        req: {
+          headers: {},
+        },
+      },
+    });
+
+    render(<Component {...props} />);
+    expect(getRemoteConfig("remoteConfig1")).toBe("FooBar");
   });
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/react
 
+## 5.0.0
+
+### Major Changes
+
+- add remote config
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@5.0.0
+
 ## 4.2.0
 
 ### Minor Changes

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tryabby/react",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "",
   "main": "dist/index.js",
   "files": [

--- a/packages/react/src/StorageService.ts
+++ b/packages/react/src/StorageService.ts
@@ -1,6 +1,7 @@
 import {
   getABStorageKey,
   getFFStorageKey,
+  getRCStorageKey,
   type IStorageService,
 } from "@tryabby/core";
 import Cookie from "js-cookie";
@@ -39,5 +40,21 @@ class FFStorageService implements IStorageService {
   }
 }
 
+class RCStorageService implements IStorageService {
+  get(projectId: string, key: string): string | null {
+    const retrievedValue = Cookie.get(getRCStorageKey(projectId, key));
+    return retrievedValue ?? null;
+  }
+
+  set(projectId: string, key: string, value: string): void {
+    Cookie.set(getRCStorageKey(projectId, key), value);
+  }
+
+  remove(projectId: string, key: string): void {
+    Cookie.remove(getRCStorageKey(projectId, key));
+  }
+}
+
 export const TestStorageService = new ABStorageService();
 export const FlagStorageService = new FFStorageService();
+export const RemoteConfigStorageService = new RCStorageService();

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -9,7 +9,11 @@ import React, { useCallback, useEffect, useRef, useState, type PropsWithChildren
 import { HttpService } from "@tryabby/core";
 import { AbbyDataResponse, AbbyEventType } from "@tryabby/core";
 import { F } from "ts-toolbelt";
-import { FlagStorageService, TestStorageService } from "./StorageService";
+import {
+  FlagStorageService,
+  RemoteConfigStorageService,
+  TestStorageService,
+} from "./StorageService";
 import type { AbbyDevtoolProps, DevtoolsFactory } from "@tryabby/devtools";
 
 export type withDevtoolsFunction = (
@@ -59,6 +63,16 @@ export function createAbby<
       set: (key: string, value: any) => {
         if (typeof window === "undefined") return;
         FlagStorageService.set(abbyConfig.projectId, key, value);
+      },
+    },
+    {
+      get: (key: string) => {
+        if (typeof window === "undefined") return null;
+        return RemoteConfigStorageService.get(abbyConfig.projectId, key);
+      },
+      set: (key: string, value: any) => {
+        if (typeof window === "undefined") return;
+        RemoteConfigStorageService.set(abbyConfig.projectId, key, value);
       },
     }
   );

--- a/packages/react/tests/mocks/handlers.ts
+++ b/packages/react/tests/mocks/handlers.ts
@@ -19,7 +19,13 @@ const returnData: AbbyDataResponse = {
     },
     {
       name: "flag2",
-      value: "test",
+      value: false,
+    },
+  ],
+  remoteConfig: [
+    {
+      name: "remoteConfig1",
+      value: "FooBar",
     },
   ],
 };

--- a/packages/react/tests/ssr.test.tsx
+++ b/packages/react/tests/ssr.test.tsx
@@ -53,6 +53,7 @@ describe("useAbby", () => {
               weights: [0.5, 0.5],
             },
           ],
+          remoteConfig: [],
         }}
       >
         <ComponentWithFF />
@@ -70,10 +71,7 @@ describe("useFeatureFlag", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        test: "Boolean",
-        test2: "Boolean",
-      },
+      flags: ["test", "test2"],
     });
 
     const ComponentWithFF = () => {
@@ -102,6 +100,7 @@ describe("useFeatureFlag", () => {
             },
           ],
           tests: [],
+          remoteConfig: [],
         }}
       >
         <ComponentWithFF />
@@ -110,5 +109,48 @@ describe("useFeatureFlag", () => {
 
     expect(serverSideDOM).toContain("Secret");
     expect(serverSideDOM).not.toContain("SUPER SECRET");
+  });
+});
+
+describe("getRemoteConfig", () => {
+  it("renders the correct remoteConfig value on the server", () => {
+    const { AbbyProvider, useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: { remoteConfig1: "String" },
+    });
+
+    const ComponentWithRC = () => {
+      const remoteConfig1 = useRemoteConfig("remoteConfig1");
+
+      return (
+        <>
+          <span data-testid="test">{remoteConfig1}</span>
+        </>
+      );
+    };
+
+    const serverSideDOM = renderToString(
+      <AbbyProvider
+        initialData={{
+          flags: [
+            {
+              value: true,
+              name: "test",
+            },
+            {
+              value: false,
+              name: "test2",
+            },
+          ],
+          tests: [],
+          remoteConfig: [{ name: "remoteConfig1", value: "FooBar" }],
+        }}
+      >
+        <ComponentWithRC />
+      </AbbyProvider>
+    );
+
+    expect(serverSideDOM).toContain("FooBar");
   });
 });

--- a/packages/react/tests/types.test.tsx
+++ b/packages/react/tests/types.test.tsx
@@ -53,10 +53,7 @@ describe("useFeatureFlag", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        test: "Boolean",
-        test2: "String",
-      },
+      flags: ["test"],
     });
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
@@ -64,12 +61,9 @@ describe("useFeatureFlag", () => {
     const { result: testFlagResult } = renderHook(() => useFeatureFlag("test"), {
       wrapper,
     });
-    const { result: test2FlagResult } = renderHook(() => useFeatureFlag("test2"), {
-      wrapper,
-    });
 
     expectTypeOf(testFlagResult.current).toEqualTypeOf<boolean>();
-    expectTypeOf(test2FlagResult.current).toEqualTypeOf<string>();
+    expectTypeOf(useFeatureFlag).parameter(0).toEqualTypeOf<"test">();
   });
 
   // TODO: the types don't work for this yet
@@ -78,15 +72,11 @@ describe("useFeatureFlag", () => {
       environments: [],
       projectId: "123",
       currentEnvironment: "test",
-      flags: {
-        test: "Boolean",
-        test2: "String",
-      },
+      flags: ["test"],
       settings: {
         flags: {
           devOverrides: {
             test: true,
-            test2: "test",
           },
         },
       },
@@ -104,9 +94,7 @@ describe("useFeatureFlag", () => {
             variants: ["ONLY_ONE_VARIANT"],
           },
         },
-        flags: {
-          test: "Boolean",
-        },
+        flags: ["test"],
         settings: {
           flags: {
             devOverrides: {
@@ -117,5 +105,36 @@ describe("useFeatureFlag", () => {
       });
       expectTypeOf(getVariants("test")).toEqualTypeOf<["ONLY_ONE_VARIANT"]>();
     });
+  });
+});
+
+describe("useRemoteConfig", () => {
+  it("uses correct typings", () => {
+    const { AbbyProvider, useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        stringRc: "String",
+        numberRc: "Number",
+        jsonRc: "JSON",
+      },
+    });
+
+    expectTypeOf(useRemoteConfig).parameter(0).toEqualTypeOf<"stringRc" | "numberRc" | "jsonRc">();
+
+    const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
+    const { result: stringRcResult } = renderHook(() => useRemoteConfig("stringRc"), {
+      wrapper,
+    });
+    const { result: numberRcResult } = renderHook(() => useRemoteConfig("numberRc"), {
+      wrapper,
+    });
+    const { result: jsonRcResult } = renderHook(() => useRemoteConfig("jsonRc"), {
+      wrapper,
+    });
+
+    expectTypeOf(stringRcResult.current).toEqualTypeOf<string>();
+    expectTypeOf(numberRcResult.current).toEqualTypeOf<number>();
+    expectTypeOf(jsonRcResult.current).toEqualTypeOf<Record<string, unknown>>();
   });
 });

--- a/packages/react/tests/useAbby.test.tsx
+++ b/packages/react/tests/useAbby.test.tsx
@@ -148,10 +148,7 @@ describe("useAbby", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1", "flag2"],
     });
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
@@ -167,31 +164,29 @@ describe("useAbby", () => {
       wrapper,
     });
 
-    expect(flag2.current).toEqual("");
+    expect(flag2.current).toEqual(false);
 
     // wait for the flag to be fetched
-    waitFor(() => expect(flag2.current).toEqual("test"));
+    waitFor(() => expect(flag2.current).toEqual(false));
   });
 
   it("should respect the default values for feature flags", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "Boolean",
-      },
+      flags: ["flag1", "flag2"],
       currentEnvironment: "a",
     });
 
     const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
 
-    const { result: flag2 } = renderHook(() => useFeatureFlag("flag2"), {
+    const { result: flag1 } = renderHook(() => useFeatureFlag("flag1"), {
       wrapper,
     });
+    expect(flag1.current).toEqual(false);
 
     // wait for the flag to be fetched
-    waitFor(() => expect(flag2.current).toEqual(false));
+    waitFor(() => expect(flag1.current).toEqual(false));
   });
 
   it("uses the devOverrides", () => {
@@ -199,10 +194,7 @@ describe("useAbby", () => {
     const { AbbyProvider, useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "Boolean",
-      },
+      flags: ["flag1", "flag2"],
       currentEnvironment: "a",
       settings: {
         flags: {
@@ -239,10 +231,7 @@ describe("useAbby", () => {
     const { getFeatureFlagValue } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "Boolean",
-      },
+      flags: ["flag1", "flag2"],
       currentEnvironment: "a",
     });
 
@@ -335,6 +324,62 @@ describe("useAbby", () => {
 
     expectTypeOf(result.current.variant).toEqualTypeOf<"Hello" | "Bonjour" | "Hola">();
   });
+
+  it("returns correct remoteConfigValue", () => {
+    const { useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        remoteConfig1: "String",
+      },
+      currentEnvironment: "a",
+    });
+
+    // await server fetch
+    waitFor(() => expect(useRemoteConfig("remoteConfig1")).toEqual("FooBar"));
+  });
+
+  it("uses defaultValues when remoteConfig is not set", () => {
+    const { useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        unsetRemoteConfig: "String",
+      },
+      settings: {
+        remoteConfig: {
+          defaultValues: {
+            String: "defaultValue",
+          },
+        },
+      },
+      currentEnvironment: "a",
+    });
+
+    // await server fetch
+    waitFor(() => expect(useRemoteConfig("unsetRemoteConfig")).toEqual("defaultValue"));
+  });
+
+  it("uses devOverride for remoteConfig", () => {
+    const { useRemoteConfig } = createAbby({
+      environments: [],
+      projectId: "123",
+      remoteConfig: {
+        remoteConfig1: "String",
+      },
+      settings: {
+        remoteConfig: {
+          devOverrides: {
+            remoteConfig1: "overwrittenValue",
+          },
+        },
+      },
+      currentEnvironment: "a",
+    });
+
+    // await server fetch
+    waitFor(() => expect(useRemoteConfig("remoteConfig1")).toEqual("overwrittenValue"));
+  });
 });
 
 it("has the correct types", () => {
@@ -347,10 +392,7 @@ it("has the correct types", () => {
         variants: ["SimonsText", "MatthiasText", "TomsText", "TimsText"],
       },
     },
-    flags: {
-      flag1: "Boolean",
-      flag2: "String",
-    },
+    flags: ["flag1"],
   });
 
   const wrapper = ({ children }: PropsWithChildren) => <AbbyProvider>{children}</AbbyProvider>;
@@ -363,17 +405,11 @@ it("has the correct types", () => {
 
   expectTypeOf(result.current.variant).toEqualTypeOf<"OldFooter" | "NewFooter">();
 
-  expectTypeOf(useFeatureFlag).parameters.toEqualTypeOf<["flag1" | "flag2"]>();
+  expectTypeOf(useFeatureFlag).parameters.toEqualTypeOf<["flag1"]>();
 
   const { result: ffResult } = renderHook(() => useFeatureFlag("flag1"), {
     wrapper,
   });
 
   expectTypeOf(ffResult.current).toEqualTypeOf<boolean>();
-
-  const { result: ff2Result } = renderHook(() => useFeatureFlag("flag2"), {
-    wrapper,
-  });
-
-  expectTypeOf(ff2Result.current).toEqualTypeOf<string>();
 });

--- a/packages/svelte/CHANGELOG.md
+++ b/packages/svelte/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @tryabby/svelte
 
+## 2.0.0
+
+### Major Changes
+
+- add remote config
+
+### Patch Changes
+
+- Updated dependencies
+  - @tryabby/core@5.0.0
+
 ## 1.2.0
 
 ### Minor Changes

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@tryabby/svelte",
-	"version": "1.2.0",
+	"version": "2.0.0",
 	"main": "dist/index.umd.cjs",
 	"homepage": "https://docs.tryabby.dev",
 	"type": "module",

--- a/packages/svelte/src/lib/StorageService.ts
+++ b/packages/svelte/src/lib/StorageService.ts
@@ -1,6 +1,7 @@
 import {
   getABStorageKey,
   getFFStorageKey,
+  getRCStorageKey,
   type IStorageService,
 } from "@tryabby/core";
 import Cookie from "js-cookie";
@@ -39,5 +40,19 @@ class FFStorageService implements IStorageService {
   }
 }
 
+class RCStorageService implements IStorageService {
+  get(projectId: string, key: string): string {
+    const retrievedValue = Cookie.get(getRCStorageKey(projectId, key));
+    return retrievedValue ?? null;
+  }
+  set(projectId: string, key: string, value: string): void {
+    Cookie.set(getRCStorageKey(projectId, key), value);
+  }
+  remove(projectId: string, key: string): void {
+    Cookie.remove(getRCStorageKey(projectId, key));
+  }
+}
+
 export const TestStorageService = new ABStorageService();
 export const FlagStorageService = new FFStorageService();
+export const RemoteConfigStorageService = new RCStorageService();

--- a/packages/svelte/src/lib/createAbby.ts
+++ b/packages/svelte/src/lib/createAbby.ts
@@ -9,7 +9,11 @@ import { HttpService, AbbyEventType } from "@tryabby/core";
 import { derived, type Readable } from "svelte/store";
 import type { F } from "ts-toolbelt";
 // import type { LayoutServerLoad, LayoutServerLoadEvent } from "../routes/$types"; TODO fix import
-import { FlagStorageService, TestStorageService } from "./StorageService";
+import {
+  FlagStorageService,
+  RemoteConfigStorageService,
+  TestStorageService,
+} from "./StorageService";
 import AbbyProvider from "./AbbyProvider.svelte";
 import AbbyDevtools from "./AbbyDevtools.svelte";
 
@@ -53,6 +57,16 @@ export function createAbby<
       set: (key: string, value: any) => {
         if (typeof window === "undefined") return;
         FlagStorageService.set(config.projectId, key, value);
+      },
+    },
+    {
+      get: (key: string) => {
+        if (typeof window === "undefined") return null;
+        return RemoteConfigStorageService.get(config.projectId, key);
+      },
+      set: (key: string, value: any) => {
+        if (typeof window === "undefined") return;
+        RemoteConfigStorageService.set(config.projectId, key, value);
       },
     }
   );

--- a/packages/svelte/src/lib/createAbby.ts
+++ b/packages/svelte/src/lib/createAbby.ts
@@ -1,4 +1,10 @@
-import { Abby, type AbbyConfig, type ABConfig, type FlagValueString } from "@tryabby/core";
+import {
+  Abby,
+  type AbbyConfig,
+  type ABConfig,
+  type RemoteConfigValueString,
+  type RemoteConfigValueStringToType,
+} from "@tryabby/core";
 import { HttpService, AbbyEventType } from "@tryabby/core";
 import { derived, type Readable } from "svelte/store";
 import type { F } from "ts-toolbelt";
@@ -17,10 +23,17 @@ export function createAbby<
   FlagName extends string,
   TestName extends string,
   Tests extends Record<TestName, ABConfig>,
-  Flags extends Record<FlagName, FlagValueString> = Record<FlagName, FlagValueString>,
-  ConfigType extends AbbyConfig<FlagName, Tests> = AbbyConfig<FlagName, Tests>
->(config: F.Narrow<AbbyConfig<FlagName, Tests, Flags>>) {
-  const abby = new Abby<FlagName, TestName, Tests, Flags>(
+  RemoteConfig extends Record<RemoteConfigName, RemoteConfigValueString>,
+  RemoteConfigName extends Extract<keyof RemoteConfig, string>,
+  ConfigType extends AbbyConfig<FlagName, Tests> = AbbyConfig<
+    FlagName,
+    Tests,
+    string[],
+    RemoteConfigName,
+    RemoteConfig
+  >
+>(config: F.Narrow<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>>) {
+  const abby = new Abby<FlagName, TestName, Tests, RemoteConfig, RemoteConfigName>(
     config,
     {
       get: (key: string) => {
@@ -134,13 +147,27 @@ export function createAbby<
     return lookupObject[variant as keyof typeof lookupObject] as any;
   };
 
-  const getFeatureFlagValue = <F extends keyof Flags>(featureFlagName: F) => {
+  const getFeatureFlagValue = (featureFlagName: FlagName) => {
     return abby.getFeatureFlag(featureFlagName);
   };
 
-  const useFeatureFlag = <F extends keyof Flags>(flagName: F) => {
+  const useFeatureFlag = (flagName: FlagName) => {
     return derived(abby, ($v) => {
       return abby.getFeatureFlag(flagName);
+    });
+  };
+
+  const getRemoteConfig = <T extends RemoteConfigName, Config extends RemoteConfig[T]>(
+    remoteConfigName: T
+  ): RemoteConfigValueStringToType<Config> => {
+    return abby.getRemoteConfig(remoteConfigName);
+  };
+
+  const useRemoteConfig = <T extends RemoteConfigName, Config extends RemoteConfig[T]>(
+    remoteConfigName: T
+  ): Readable<RemoteConfigValueStringToType<Config>> => {
+    return derived(abby, ($v) => {
+      return abby.getRemoteConfig(remoteConfigName);
     });
   };
 
@@ -170,6 +197,8 @@ export function createAbby<
     useAbby,
     useFeatureFlag,
     getFeatureFlagValue,
+    getRemoteConfig,
+    useRemoteConfig,
     getABTestValue,
     __abby__: abby,
     getABResetFunction,

--- a/packages/svelte/src/tests/abby.ts
+++ b/packages/svelte/src/tests/abby.ts
@@ -8,8 +8,8 @@ export const abby = createAbby({
       variants: ["A", "B"],
     },
   },
-  flags: {
-    flag1: "Boolean",
-    flag2: "String",
+  flags: ["flag1"],
+  remoteConfig: {
+    remoteConfig1: "String",
   },
 });

--- a/packages/svelte/src/tests/featureFlags.test.ts
+++ b/packages/svelte/src/tests/featureFlags.test.ts
@@ -7,49 +7,37 @@ const OLD_ENV = process.env;
 describe("featureFlags working", () => {
   it("should return the correct feature flags", async () => {
     const FLAG1 = "flag1";
-    const FLAG2 = "flag2";
 
     const { useFeatureFlag, __abby__ } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        [FLAG1]: "Boolean",
-        [FLAG2]: "String",
-      },
+      flags: [FLAG1],
     });
 
     // await server fetch
     await __abby__.loadProjectData();
 
     const recievedFlag1 = get(useFeatureFlag(FLAG1));
-    const recievedFlag2 = get(useFeatureFlag(FLAG2));
     expect(recievedFlag1).toEqual(true);
-    expect(recievedFlag2).toEqual("someValue");
   });
 
   it("should respect the default values for feature flags", async () => {
     const { useFeatureFlag, __abby__ } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
       currentEnvironment: "a",
       settings: {
         flags: {
-          defaultValues: {
-            Boolean: false,
-            String: "default",
-          },
+          defaultValue: false,
         },
       },
     });
-    const flag2 = get(useFeatureFlag("flag2"));
-    expect(flag2).toEqual("default");
+    const flag1 = get(useFeatureFlag("flag1"));
+    expect(flag1).toEqual(false);
     // wait for the flag to be fetched
     await __abby__.loadProjectData();
-    expect(get(useFeatureFlag("flag2"))).toEqual("someValue");
+    expect(get(useFeatureFlag("flag1"))).toEqual(true);
   });
 
   it("uses the devOverrides", () => {
@@ -57,43 +45,28 @@ describe("featureFlags working", () => {
     const { useFeatureFlag } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
       currentEnvironment: "a",
       settings: {
         flags: {
           devOverrides: {
             flag1: false,
-            flag2: "devDefault",
           },
         },
       },
     });
     const flag1 = get(useFeatureFlag("flag1"));
-
     expect(flag1).toEqual(false);
 
     // will stay false and won't be overwritten by a fetch
     expect(get(useFeatureFlag("flag1"))).toEqual(false);
-
-    const flag2 = get(useFeatureFlag("flag2"));
-
-    expect(flag2).toEqual("devDefault");
-
-    // will stay true and won't be overwritten by a fetch
-    expect(get(useFeatureFlag("flag2"))).toEqual("devDefault");
   });
 
   it("gets the value for an enviroment", async () => {
     const { getFeatureFlagValue, __abby__ } = createAbby({
       environments: [],
       projectId: "123",
-      flags: {
-        flag1: "Boolean",
-        flag2: "String",
-      },
+      flags: ["flag1"],
       currentEnvironment: "a",
     });
 
@@ -101,6 +74,5 @@ describe("featureFlags working", () => {
     await __abby__.loadProjectData();
 
     expect(getFeatureFlagValue("flag1")).toEqual(true);
-    expect(getFeatureFlagValue("flag2")).toEqual("someValue");
   });
 });

--- a/packages/svelte/src/tests/mocks/handlers.ts
+++ b/packages/svelte/src/tests/mocks/handlers.ts
@@ -17,9 +17,11 @@ const returnData: AbbyDataResponse = {
       name: "flag1",
       value: true,
     },
+  ],
+  remoteConfig: [
     {
-      name: "flag2",
-      value: "someValue",
+      name: "remoteConfig1",
+      value: "FooBar",
     },
   ],
 };

--- a/packages/svelte/src/tests/pages/+test.svelte
+++ b/packages/svelte/src/tests/pages/+test.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
   import { abby } from "../abby";
   export let data: { __abby__data: any; __abby_cookie: any };
-  const { useFeatureFlag, AbbyProvider } = abby;
+  const { useFeatureFlag, AbbyProvider, useRemoteConfig } = abby;
   const flag1 = useFeatureFlag("flag1");
-  const flag2 = useFeatureFlag("flag2");
+  const remoteConfig1 = useRemoteConfig("remoteConfig1");
 </script>
 
 <body>
@@ -12,8 +12,8 @@
       <div id="flag1Enabled">my super secret feature 1</div>
     {/if}
 
-    {#if $flag2 !== "someValue"}
-      <div id="flag2Enabled">my super secret feature 2</div>
+    {#if $remoteConfig1 !== "FooBar"}
+      <div id="remoteConfig1">my remoteConfig1 value</div>
     {/if}
   </AbbyProvider>
 </body>

--- a/packages/svelte/src/tests/remoteConfig.test.ts
+++ b/packages/svelte/src/tests/remoteConfig.test.ts
@@ -1,0 +1,58 @@
+import { get } from "svelte/store";
+import { createAbby } from "../lib/createAbby";
+import { it, describe, expect } from "vitest";
+
+describe("remoteConfig", () => {
+  it("returns the correct remoteConfig value", async () => {
+    const { useRemoteConfig, __abby__ } = createAbby({
+      projectId: "123",
+      remoteConfig: { remoteConfig1: "String" },
+      environments: [],
+    });
+
+    await __abby__.loadProjectData();
+
+    const actual = get(useRemoteConfig("remoteConfig1"));
+    expect(actual).toBe("FooBar");
+  });
+
+  it("uses the default values for remoteConfig", async () => {
+    const { useRemoteConfig, __abby__ } = createAbby({
+      projectId: "123",
+      remoteConfig: { remoteConfig1: "String" },
+      environments: [],
+      settings: {
+        remoteConfig: {
+          defaultValues: {
+            String: "testDefaultValue",
+          },
+        },
+      },
+    });
+
+    expect(get(useRemoteConfig("remoteConfig1"))).toBe("testDefaultValue");
+
+    await __abby__.loadProjectData();
+    expect(get(useRemoteConfig("remoteConfig1"))).toBe("FooBar");
+  });
+
+  it("uses the devOverrides", async () => {
+    process.env.NODE_ENV = "development";
+    const { useRemoteConfig, __abby__ } = createAbby({
+      projectId: "123",
+      currentEnvironment: "a",
+      remoteConfig: { remoteConfig1: "String" },
+      environments: [],
+      settings: {
+        remoteConfig: {
+          devOverrides: {
+            remoteConfig1: "devOverride",
+          },
+        },
+      },
+    });
+
+    await __abby__.loadProjectData();
+    expect(get(useRemoteConfig("remoteConfig1"))).toBe("devOverride");
+  });
+});

--- a/packages/svelte/src/tests/withAbby.test.ts
+++ b/packages/svelte/src/tests/withAbby.test.ts
@@ -23,7 +23,7 @@ describe("withabby working", () => {
     });
     const flag1 = await waitFor(() => getByText("my super secret feature 1"));
     expect(flag1).toBeInTheDocument();
-    const flag2 = queryByText("my super secret feature 2");
-    expect(flag2).not.toBeInTheDocument();
+    const remoteConfig1 = queryByText("my remoteConfig1 value");
+    expect(remoteConfig1).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
- Create a new menu entry for _remote config_
- Move all non-boolean flags in the UI there
- Move A/B tests down in menu hierarchy

Questions:
1. Should we add the `remoteConfig` option to the A/BBY config in the code as well?
2. Should we add a new hook `useRemoteConfig`? (and the same for angular)