### PR TITLE
fix(cli): fix cli resolving env variables in abby.config.ts

### DIFF
--- a/apps/angular-example/abby.config.ts
+++ b/apps/angular-example/abby.config.ts
@@ -1,22 +1,26 @@
 import { defineConfig } from "@tryabby/angular";
 import { environment } from "src/environments/environment";
 
-export default defineConfig({
-  projectId: environment.ABBY_PROJECT_ID,
-  currentEnvironment: "test",
-  environments: ["test", "prod"],
-  tests: {
-    AngularTest: {
-      variants: ["A", "B", "C", "D"],
-    },
-    NotExistingTest: {
-      variants: ["A", "B"],
-    },
+export default defineConfig(
+  {
+    projectId: environment.ABBY_PROJECT_ID,
+    currentEnvironment: "test",
+    apiUrl: "http://localhost:3000/",
+    debug: true,
   },
-  flags: ["AngularFlag", "AngularFlag2", "NotExistingFlag"],
-  remoteConfig: {
-    angularRemoteConfig: "String",
-  },
-  apiUrl: "http://localhost:3000/",
-  debug: true,
-});
+  {
+    environments: ["test", "prod"],
+    tests: {
+      AngularTest: {
+        variants: ["A", "B", "C", "D"],
+      },
+      NotExistingTest: {
+        variants: ["A", "B"],
+      },
+    },
+    flags: ["AngularFlag", "AngularFlag2", "NotExistingFlag"],
+    remoteConfig: {
+      angularRemoteConfig: "String",
+    },
+  }
+);

--- a/apps/docs/pages/config.mdx
+++ b/apps/docs/pages/config.mdx
@@ -1,3 +1,5 @@
+import { Callout } from "nextra-theme-docs";
+
 # Configuration as Code
 
 ## Introduction
@@ -20,10 +22,21 @@ The config needs to be the default export of the file so that the CLI can find i
 import { defineConfig } from "@tryabby/core";
 // or import { defineConfig } from "@tryabby/<integration>";
 
-export default defineConfig({
-  // your config here
-});
+export default defineConfig(
+  {
+    // your projectId and other sensitive data here
+  },
+  {
+    // your flags, tests, etc. here
+  }
+);
 ```
+
+<Callout type="info" emoji="💡">
+  The first parameter includes all data that might be configured via environment variables.
+  You should not use environment variables in the second parameter, because the type inference
+  might suffer and the CLI could potentially resolve those environment variables!
+</Callout>
 
 ## Philosophy
 
@@ -47,47 +60,52 @@ any further configuration.
 import { defineConfig } from "@tryabby/core";
 // or import { defineConfig } from "@tryabby/<integration>";
 
-export default defineConfig({
-  projectId: "my-project-id",
-  currentEnvironment: "development",
-  environments: ["development", "production"],
-  tests: {
-    SignupButton: {
-      variants: ["A", "B"],
-    },
+export default defineConfig(
+  {
+    projectId: "my-project-id",
+    currentEnvironment: "development",
   },
-  flags: ["showFooter"],
-  remoteConfig: {
-    customButtonText: "String",
-    maxUserCount: "Number",
-    AdvancedTestStats: "JSON",
-  },
-  settings: {
-    flags: {
-      defaultValue: false,
-      devOverrides: {
-        showFooter: true,
+  {
+    environments: ["development", "production"],
+    tests: {
+      SignupButton: {
+        variants: ["A", "B"],
       },
     },
+    flags: ["showFooter"],
     remoteConfig: {
-      defaultValues: {
-        JSON: {},
-        Number: 0,
-        String: "",
+      customButtonText: "String",
+      maxUserCount: "Number",
+      AdvancedTestStats: "JSON",
+    },
+    settings: {
+      flags: {
+        defaultValue: false,
+        devOverrides: {
+          showFooter: true,
+        },
       },
-      devOverrides: {
-        maxUserCount: 40,
-        AdvancedTestStats: {},
-        customButtonText: "My cool button",
+      remoteConfig: {
+        defaultValues: {
+          JSON: {},
+          Number: 0,
+          String: "",
+        },
+        devOverrides: {
+          maxUserCount: 40,
+          AdvancedTestStats: {},
+          customButtonText: "My cool button",
+        },
       },
     },
-  },
-});
+  }
+);
 ```
 
 ## Config Reference
 
-The `defineCOnfig` function takes an object as a parameter. The object can contain the following properties:
+The `defineConfig` function takes two objects as a parameter, that will be merged together when read.
+The merged object can contain the following properties:
 
 | Name               | Type     | Required | Description                                              | details               |
 | ------------------ | -------- | :------: | -------------------------------------------------------- | --------------------- |

--- a/apps/web/abby.config.ts
+++ b/apps/web/abby.config.ts
@@ -1,21 +1,25 @@
 /* eslint-disable turbo/no-undeclared-env-vars */
 import { defineConfig } from "@tryabby/core";
 
-export default defineConfig({
-  projectId: process.env.NEXT_PUBLIC_ABBY_PROJECT_ID!,
-  currentEnvironment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
-  environments: ["development", "production"],
-  apiUrl: process.env.NEXT_PUBLIC_ABBY_API_URL,
-  tests: {
-    SignupButton: {
-      variants: ["A", "B"],
-    },
-    TipsAndTricks: {
-      variants: ["Blog"],
-    },
+export default defineConfig(
+  {
+    projectId: process.env.NEXT_PUBLIC_ABBY_PROJECT_ID!,
+    currentEnvironment: process.env.VERCEL_ENV ?? process.env.NODE_ENV,
+    apiUrl: process.env.NEXT_PUBLIC_ABBY_API_URL,
   },
-  flags: ["AdvancedTestStats", "showFooter", "test"],
-  remoteConfig: {
-    abc: "JSON",
-  },
-});
+  {
+    environments: ["development", "production"],
+    tests: {
+      SignupButton: {
+        variants: ["A", "B"],
+      },
+      TipsAndTricks: {
+        variants: ["Blog"],
+      },
+    },
+    flags: ["AdvancedTestStats", "showFooter", "test"],
+    remoteConfig: {
+      abc: "JSON",
+    },
+  }
+);

--- a/packages/cli/src/consts.ts
+++ b/packages/cli/src/consts.ts
@@ -4,5 +4,3 @@ import os from "os";
 export const ABBY_BASE_URL = "https://www.tryabby.com";
 
 export const getTokenFilePath = () => path.join(os.homedir(), ".abby");
-
-export const configRegex = /defineConfig\(([\s\S]+)\)/g;

--- a/packages/cli/src/init.ts
+++ b/packages/cli/src/init.ts
@@ -1,11 +1,14 @@
-import { AbbyConfigFile } from "@tryabby/core";
+import { AbbyConfigFile, DynamicConfigKeys } from "@tryabby/core";
 import fs from "fs/promises";
 import * as prettier from "prettier";
 
 export async function initAbbyConfig({ path }: { path: string }) {
-  const config: AbbyConfigFile = {
+  const dynamicConfig: Pick<AbbyConfigFile, DynamicConfigKeys> = {
     projectId: "<YOUR_PROJECT_ID>",
     currentEnvironment: "<YOUR_ENVIRONMENT>",
+  };
+
+  const staticConfig: Omit<AbbyConfigFile, DynamicConfigKeys> = {
     environments: [],
   };
 
@@ -13,7 +16,11 @@ export async function initAbbyConfig({ path }: { path: string }) {
   import { defineConfig } from '@tryabby/core';
 
 
-    export default defineConfig(${JSON.stringify(config, null, 2)});
+    export default defineConfig(${JSON.stringify(dynamicConfig, null, 2)}, ${JSON.stringify(
+      staticConfig,
+      null,
+      2
+    )});
   `;
 
   await fs.writeFile(path, await prettier.format(fileContent, { parser: "typescript" }));

--- a/packages/cli/src/pull.ts
+++ b/packages/cli/src/pull.ts
@@ -1,14 +1,33 @@
 import * as fs from "fs/promises";
-import { AbbyConfig, PullAbbyConfigResponse } from "@tryabby/core";
+import {
+  AbbyConfig,
+  PullAbbyConfigResponse,
+  DynamicConfigKeys,
+  DYNAMIC_ABBY_CONFIG_KEYS,
+} from "@tryabby/core";
 import { loadLocalConfig } from "./util";
 import { HttpService } from "./http";
-import { configRegex } from "./consts";
 import deepmerge from "deepmerge";
 import * as prettier from "prettier";
 
-export function updateConfigFile(updatedConfig: AbbyConfig, configFileString: string) {
-  const matchRegex = configRegex.exec(configFileString);
+export function updateConfigFile(
+  updatedConfig: Omit<AbbyConfig, DynamicConfigKeys>,
+  configFileString: string
+) {
+  // filter out keys that are marked as dynamic. Those are set in the
+  // first parameter of `defineConfig`, but we are only updating the
+  // second parameter.
+  updatedConfig = Object.fromEntries(
+    Object.entries(updatedConfig).filter(
+      ([key]) => !(DYNAMIC_ABBY_CONFIG_KEYS as readonly string[]).includes(key)
+    )
+  ) as Omit<AbbyConfig, DynamicConfigKeys>;
 
+  // remove new lines
+  configFileString = configFileString.replace(/(?:\r\n|\r|\n)/g, "");
+
+  const configRegex = /defineConfig.*, *({.*})/g;
+  const matchRegex = configRegex.exec(configFileString);
   const matchedObject = matchRegex?.at(1);
 
   if (!matchedObject) {

--- a/packages/cli/tests/abby.config.stub.ts
+++ b/packages/cli/tests/abby.config.stub.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from "@tryabby/core";
+
+export default defineConfig(
+  {
+    projectId: process.env["ABBY_PROJECT_ID"]!,
+  },
+  {
+    environments: [],
+    tests: {
+      test1: {
+        variants: ["A", "B", "C", "D"],
+      },
+      test2: {
+        variants: ["A", "B"],
+      },
+    },
+    flags: ["flag1"],
+    remoteConfig: { flag2: "Number" },
+  }
+);

--- a/packages/cli/tests/base.test.ts
+++ b/packages/cli/tests/base.test.ts
@@ -1,43 +1,40 @@
-import { AbbyConfig, PullAbbyConfigResponse } from "@tryabby/core";
+import { PullAbbyConfigResponse, defineConfig } from "@tryabby/core";
 import { HttpService } from "../src/http";
 import { writeFile } from "fs/promises";
 
 import { push } from "../src/push";
 import { pullAndMerge } from "../src/pull";
 
-vi.mock("../src/util", () => ({
-  loadLocalConfig: () =>
-    Promise.resolve({ config: sampleLocalConfig, configFilePath: "test-path" }),
-}));
-
 // we don't want to actually write to the file system
 vi.mock("prettier", () => ({
   format: (str: string) => str,
 }));
 
-vi.mock("fs/promises", () => ({
-  ...vi.importActual("fs/promises"),
-  readFile: () =>
-    Promise.resolve(`export default defineConfig(${JSON.stringify(sampleLocalConfig)});`),
+vi.mock("fs/promises", async () => ({
+  ...((await vi.importActual("fs/promises")) as object),
   writeFile: vi.fn(),
 }));
 
 const API_KEY = "test";
 
-const sampleLocalConfig = {
-  environments: [],
-  projectId: "test",
-  tests: {
-    test1: {
-      variants: ["A", "B", "C", "D"],
-    },
-    test2: {
-      variants: ["A", "B"],
-    },
+const sampleLocalConfig = [
+  {
+    projectId: "test",
   },
-  flags: ["flag1"],
-  remoteConfig: { flag2: "Number" },
-} satisfies AbbyConfig;
+  {
+    environments: [],
+    tests: {
+      test1: {
+        variants: ["A", "B", "C", "D"],
+      },
+      test2: {
+        variants: ["A", "B"],
+      },
+    },
+    flags: ["flag1"],
+    remoteConfig: { flag2: "Number" },
+  },
+] satisfies Parameters<typeof defineConfig>;
 
 const sampleServerConfig = {
   environments: ["test"],
@@ -57,15 +54,19 @@ const sampleServerConfig = {
 } satisfies PullAbbyConfigResponse;
 
 describe("Abby CLI", () => {
+  beforeAll(() => {
+    process.env["ABBY_PROJECT_ID"] = "test";
+  });
+
   it("pushes the config properly", async () => {
     const spy = vi.spyOn(HttpService, "updateConfigOnServer");
 
-    await push({ apiKey: API_KEY });
+    await push({ apiKey: API_KEY, configPath: __dirname + "/abby.config.stub.ts" });
 
     expect(spy).toHaveBeenCalledOnce();
     expect(spy).toHaveBeenCalledWith({
       apiKey: API_KEY,
-      localAbbyConfig: sampleLocalConfig,
+      localAbbyConfig: { ...sampleLocalConfig[0], ...sampleLocalConfig[1] },
     });
   });
 
@@ -74,15 +75,33 @@ describe("Abby CLI", () => {
     spy.mockResolvedValueOnce(sampleServerConfig);
     await pullAndMerge({
       apiKey: API_KEY,
+      configPath: __dirname + "/abby.config.stub.ts",
     });
 
     expect(spy).toHaveBeenCalledOnce();
     expect(spy).toHaveBeenCalledWith({
-      projectId: sampleLocalConfig.projectId,
+      projectId: "test",
       apiKey: API_KEY,
     });
     expect(writeFile).toHaveBeenCalledOnce();
     // make sure the merged test (test 3) is included in the new file
-    expect(writeFile).toHaveBeenCalledWith("test-path", expect.stringContaining("test3"));
+    expect(writeFile).toHaveBeenCalledWith(
+      __dirname + "/abby.config.stub.ts",
+      expect.stringContaining("test3")
+    );
+  });
+
+  it("doesn't overwrite dynamic configuration values", async () => {
+    const spy = vi.spyOn(HttpService, "getConfigFromServer");
+    spy.mockResolvedValueOnce(sampleServerConfig);
+    await pullAndMerge({
+      apiKey: API_KEY,
+      configPath: __dirname + "/abby.config.stub.ts",
+    });
+
+    expect(writeFile).toHaveBeenCalledWith(
+      __dirname + "/abby.config.stub.ts",
+      expect.stringContaining(`process.env["ABBY_PROJECT_ID"]`)
+    );
   });
 });

--- a/packages/cli/tests/base.test.ts
+++ b/packages/cli/tests/base.test.ts
@@ -35,7 +35,8 @@ const sampleLocalConfig = {
       variants: ["A", "B"],
     },
   },
-  flags: { flag1: "Boolean", flag2: "Number" },
+  flags: ["flag1"],
+  remoteConfig: { flag2: "Number" },
 } satisfies AbbyConfig;
 
 const sampleServerConfig = {
@@ -51,7 +52,8 @@ const sampleServerConfig = {
       variants: ["A", "B", "C", "D"],
     },
   },
-  flags: { flag1: "Boolean", flag2: "Number", flag3: "JSON" },
+  flags: ["flag1"],
+  remoteConfig: { flag2: "Number", flag3: "JSON" },
 } satisfies PullAbbyConfigResponse;
 
 describe("Abby CLI", () => {

--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -1,11 +1,27 @@
 import { F } from "ts-toolbelt";
 import { ABConfig, AbbyConfig, RemoteConfigValueString } from ".";
 
+export const DYNAMIC_ABBY_CONFIG_KEYS = [
+  "projectId",
+  "currentEnvironment",
+  "debug",
+  "apiUrl",
+] as const satisfies readonly (keyof AbbyConfig)[];
+
+export type DynamicConfigKeys = (typeof DYNAMIC_ABBY_CONFIG_KEYS)[number];
+
 export function defineConfig<
   FlagName extends string,
   Tests extends Record<string, ABConfig>,
   RemoteConfig extends Record<RemoteConfigName, RemoteConfigValueString>,
   RemoteConfigName extends Extract<keyof RemoteConfig, string>,
->(config: F.Narrow<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>>) {
-  return config;
+>(
+  dynamicConfig: F.Narrow<
+    Pick<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>, DynamicConfigKeys>
+  >,
+  config: F.Narrow<
+    Omit<AbbyConfig<FlagName, Tests, string[], RemoteConfigName, RemoteConfig>, DynamicConfigKeys>
+  >
+) {
+  return { ...dynamicConfig, ...config };
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,7 +17,7 @@ import { getWeightedRandomVariant } from "./mathHelpers";
 import { parseCookies } from "./helpers";
 
 export * from "./shared/index";
-export { defineConfig } from "./defineConfig";
+export { defineConfig, type DynamicConfigKeys, DYNAMIC_ABBY_CONFIG_KEYS } from "./defineConfig";
 
 export type ABConfig<T extends string = string> = {
   variants: ReadonlyArray<T>;

--- a/packages/core/tests/defineConfig.test.ts
+++ b/packages/core/tests/defineConfig.test.ts
@@ -2,21 +2,23 @@ import { Abby } from "../src";
 import { defineConfig } from "../src/defineConfig";
 
 describe("defineConfig", () => {
-  const cfg = defineConfig({
-    projectId: "xd",
-    environments: ["development", "production"],
-    flags: ["a"],
-    remoteConfig: {
-      b: "String",
-      c: "Number",
-      d: "JSON",
-    },
-    tests: {
-      abTest: {
-        variants: ["true", "false"],
+  const cfg = defineConfig(
+    { projectId: "xd" },
+    {
+      environments: ["development", "production"],
+      flags: ["a"],
+      remoteConfig: {
+        b: "String",
+        c: "Number",
+        d: "JSON",
       },
-    },
-  });
+      tests: {
+        abTest: {
+          variants: ["true", "false"],
+        },
+      },
+    }
+  );
 
   const abby = new Abby(cfg);
 


### PR DESCRIPTION
We change the structure of the `defineConfig` method, to split the config arguments between dynamic and static properties. Dynamic properties can be environment variables and won't be resolved by the CLI anymore.