### PR TITLE
fix: scrolling in devtools

### DIFF
--- a/packages/devtools/src/Devtools.stories.ts
+++ b/packages/devtools/src/Devtools.stories.ts
@@ -12,6 +12,11 @@ const abbyMock = {
       "flag-1": true,
       "flag-2": false,
     },
+    remoteConfig: {
+      "config-1": "string-value",
+      "config-2": 42,
+      "config-3": {type: "object/json"}
+    },
     tests: {
       "test-1": { selectedVariant: "A", variants: ["A", "B"] },
       "test-2": { selectedVariant: "B", variants: ["A", "B"] },

--- a/packages/devtools/src/Devtools.svelte
+++ b/packages/devtools/src/Devtools.svelte
@@ -93,61 +93,63 @@
       ></small
     >
     <hr />
-    <h2>Flags:</h2>
-    {#each Object.entries(flags) as [flagName, flagValue]}
-      <Switch
-        id={flagName}
-        label={flagName}
-        checked={flagValue}
-        onChange={(newValue) => {
-          window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
-          abby.updateFlag(flagName, newValue);
-        }}
-      />
-    {/each}
-    <hr />
-    <h2>Remote Config:</h2>
-    {#each Object.entries(remoteConfig) as [remoteConfigName, remoteConfigValue]}
-      {#if typeof remoteConfigValue === "string" || typeof remoteConfigValue === "number"}
-        <Input
-          id={remoteConfigName}
-          label={remoteConfigName}
-          type={typeof remoteConfigValue === "string" ? "text" : "number"}
-          value={remoteConfigValue}
+    <div class="content">
+      <h2>Flags:</h2>
+      {#each Object.entries(flags) as [flagName, flagValue]}
+        <Switch
+          id={flagName}
+          label={flagName}
+          checked={flagValue}
           onChange={(newValue) => {
-            window.postMessage({ type: "abby:update-flag", remoteConfigName, newValue }, "*");
-            abby.updateRemoteConfig(remoteConfigName, newValue);
+            window.postMessage({ type: "abby:update-flag", flagName, newValue }, "*");
+            abby.updateFlag(flagName, newValue);
           }}
         />
-      {:else if typeof remoteConfigValue === "object"}
-        <div style="display: flex; flex-direction: column; margin: 10px 0;">
-          <p style="margin-bottom: 5px;">{remoteConfigName}</p>
-          <Modal
+      {/each}
+      <hr />
+      <h2>Remote Config:</h2>
+      {#each Object.entries(remoteConfig) as [remoteConfigName, remoteConfigValue]}
+        {#if typeof remoteConfigValue === "string" || typeof remoteConfigValue === "number"}
+          <Input
+            id={remoteConfigName}
+            label={remoteConfigName}
+            type={typeof remoteConfigValue === "string" ? "text" : "number"}
             value={remoteConfigValue}
             onChange={(newValue) => {
               window.postMessage({ type: "abby:update-flag", remoteConfigName, newValue }, "*");
               abby.updateRemoteConfig(remoteConfigName, newValue);
             }}
           />
-        </div>
-      {/if}
-    {/each}
-    <hr />
-    <h2>A/B Tests:</h2>
-    {#each Object.entries(tests) as [testName, { selectedVariant, variants }]}
-      <Select
-        label={testName}
-        value={selectedVariant}
-        options={variants.map((v) => ({
-          label: v,
-          value: v,
-        }))}
-        onChange={(newValue) => {
-          window.postMessage({ type: "abby:select-variant", testName, newValue }, "*");
-          abby.updateLocalVariant(testName, newValue);
-        }}
-      />
-    {/each}
+        {:else if typeof remoteConfigValue === "object"}
+          <div style="display: flex; flex-direction: column; margin: 10px 0;">
+            <p style="margin-bottom: 5px;">{remoteConfigName}</p>
+            <Modal
+              value={remoteConfigValue}
+              onChange={(newValue) => {
+                window.postMessage({ type: "abby:update-flag", remoteConfigName, newValue }, "*");
+                abby.updateRemoteConfig(remoteConfigName, newValue);
+              }}
+            />
+          </div>
+        {/if}
+      {/each}
+      <hr />
+      <h2>A/B Tests:</h2>
+      {#each Object.entries(tests) as [testName, { selectedVariant, variants }]}
+        <Select
+          label={testName}
+          value={selectedVariant}
+          options={variants.map((v) => ({
+            label: v,
+            value: v,
+          }))}
+          onChange={(newValue) => {
+            window.postMessage({ type: "abby:select-variant", testName, newValue }, "*");
+            abby.updateLocalVariant(testName, newValue);
+          }}
+        />
+      {/each}
+    </div>
   </div>
 {:else}
   <button
@@ -188,7 +190,9 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    box-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+    box-shadow:
+      0 10px 15px -3px rgb(0 0 0 / 0.1),
+      0 4px 6px -4px rgb(0 0 0 / 0.1);
   }
 
   #abby-devtools {
@@ -201,7 +205,7 @@
     left: var(--left);
     top: var(--top);
     background: #121929;
-    padding: 15px 10px;
+    padding-inline: 10px;
     padding-top: 10px;
     z-index: 9999;
     border-radius: 6px;
@@ -209,6 +213,9 @@
     font-size: 14px;
     color: hsl(213 31% 91%);
     min-width: 300px;
+    display: flex;
+    flex-direction: column;
+    max-height: calc(100vh - 3rem);
 
     .logo {
       font-family: "Martian Mono", inherit;
@@ -233,6 +240,27 @@
         all: unset;
         display: contents;
         cursor: pointer;
+      }
+    }
+    .content {
+      margin-top: -1rem;
+      padding-top: 1rem;
+      padding-bottom: calc(1rem - 10px);
+      overflow-y: auto;
+      &::-webkit-scrollbar {
+        width: 10px;
+      }
+      &::-webkit-scrollbar-track {
+        background-color: transparent;
+      }
+      &::-webkit-scrollbar-thumb {
+        background-color: rgba(255, 255, 255, 0.4);
+        border: 6px solid transparent;
+        border-right-width: 0px;
+        background-clip: content-box;
+        &:hover {
+          background-color: rgba(255, 255, 255, 0.6);
+        }
       }
     }
     h1,


### PR DESCRIPTION
This PR relates to #119 and makes the devtools scrollable if the height exceeds the available screen height.  It also styles the scrollbar for browsers supporting this, so that the scrollbar is less prominent but still visible.

It also fixes an issue of the DevTools story where required data (`remoteConfig`) was missing so Storybook could not render the DevTools component.

![image](https://github.com/tryabby/abby/assets/11538167/b14ac883-eb55-42c4-b8c6-06cccac79f58)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the developer tools interface with improved layout and styling, including a new scrollbar design.
  
- **Refactor**
	- Reorganized UI components within the developer tools for better user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->