### PR TITLE
fix(web): update link to segments documentation in settings page

### DIFF
--- a/apps/web/src/pages/projects/[projectId]/settings.tsx
+++ b/apps/web/src/pages/projects/[projectId]/settings.tsx
@@ -266,7 +266,7 @@ const SettingsPage: NextPageWithLayout = () => {
                     custom attributes.
                   </p>
                   <Link
-                    href="https://docs.tryabby.com/features/segments"
+                    href="https://docs.tryabby.com/user-segments"
                     target="_blank"
                     className="text-pink-400 hover:text-pink-300 underline"
                   >


### PR DESCRIPTION
Fixes broken link to documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the in-app hyperlink for user segments so that users are directed to the correct documentation page, ensuring access to the latest and accurate information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->