### PR TITLE
fix: change docker-compose to docker compose

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,8 +13,8 @@
     "seed:events": "ts-node --compiler-options {\\\"module\\\":\\\"CommonJS\\\"} prisma/seedEvents.ts",
     "db:migrate": "prisma migrate dev",
     "generate:coupons": "pnpm ts-node -r tsconfig-paths/register  --compiler-options {\\\"module\\\":\\\"CommonJS\\\"} prisma/generateCoupons.ts",
-    "mailhog:up": "docker-compose -f docker-compose.mailhog.yaml up",
-    "mailhog:down": "docker-compose -f docker-compose.mailhog.yaml down",
+    "mailhog:up": "docker compose -f docker-compose.mailhog.yaml up",
+    "mailhog:down": "docker compose -f docker-compose.mailhog.yaml down",
     "test": "vitest",
     "start:docker": "npx prisma migrate deploy || { echo 'Migration failed, exiting'; exit 1; } && node server.js"
   },

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "dev:all": "turbo run dev --filter=!./apps/docs",
     "lint": "biome lint --fix",
     "format": "biome format --write",
-    "db:start": "docker-compose up -d",
+    "db:start": "docker compose up -d",
     "db:migrate": "turbo run db:migrate --filter=./apps/web",
     "db:generate": "turbo run db:generate --filter=./apps/web",
-    "db:stop": "docker-compose down",
+    "db:stop": "docker compose down",
     "ci:publish": "pnpm publish -r --access public"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR addresses issue #173.
It replaces `docker-compose` with `docker compose`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated script commands to use the newer Docker CLI syntax for managing containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->